### PR TITLE
Add file backed task manager class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# configuration files for checkstyle plugin
+/checkstyle.xml
+/suppressions.xml
+/checkstyle.sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Additionally,
 - retrieving the list of subtasks of an epic,
 - retrieving the list of all tasks/ epics/ subtasks,
 - removing all tasks/ epics/ subtasks,
-- keeping the list of the last ten tasks/ epics/ subtasks retrieved
+- keeping the list of tasks/ epics/ subtasks retrieved.
 
 ## Contact
 

--- a/java-kanban.iml
+++ b/java-kanban.iml
@@ -6,6 +6,9 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/codeStyles" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/inspectionProfiles" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/libraries" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/main/java/io/github/akuniutka/kanban/exception/CSVParsingException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/CSVParsingException.java
@@ -1,0 +1,20 @@
+package io.github.akuniutka.kanban.exception;
+
+public class CSVParsingException extends RuntimeException {
+    private final String shortMessage;
+    private final int positionInLine;
+
+    public CSVParsingException(String message, int positionInLine) {
+        super(message + " at " + positionInLine);
+        this.shortMessage = message;
+        this.positionInLine = positionInLine;
+    }
+
+    public String getShortMessage() {
+        return shortMessage;
+    }
+
+    public int getPositionInLine() {
+        return positionInLine;
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerException.java
@@ -1,18 +1,11 @@
 package io.github.akuniutka.kanban.exception;
 
 public class ManagerException extends RuntimeException {
-    public ManagerException() {
-    }
-
     public ManagerException(String message) {
         super(message);
     }
 
     public ManagerException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public ManagerException(Throwable cause) {
-        super(cause);
     }
 }

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerException.java
@@ -1,0 +1,18 @@
+package io.github.akuniutka.kanban.exception;
+
+public class ManagerException extends RuntimeException {
+    public ManagerException() {
+    }
+
+    public ManagerException(String message) {
+        super(message);
+    }
+
+    public ManagerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ManagerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerLoadException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerLoadException.java
@@ -1,0 +1,13 @@
+package io.github.akuniutka.kanban.exception;
+
+import java.io.IOException;
+
+public class ManagerLoadException extends ManagerException {
+    public ManagerLoadException(String message) {
+        super(message);
+    }
+
+    public ManagerLoadException(String message, IOException cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchEpicException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchEpicException.java
@@ -1,0 +1,7 @@
+package io.github.akuniutka.kanban.exception;
+
+public class ManagerNoSuchEpicException extends ManagerException {
+    public ManagerNoSuchEpicException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchSubtaskException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchSubtaskException.java
@@ -1,0 +1,7 @@
+package io.github.akuniutka.kanban.exception;
+
+public class ManagerNoSuchSubtaskException extends ManagerException {
+    public ManagerNoSuchSubtaskException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchTaskException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerNoSuchTaskException.java
@@ -1,0 +1,7 @@
+package io.github.akuniutka.kanban.exception;
+
+public class ManagerNoSuchTaskException extends ManagerException {
+    public ManagerNoSuchTaskException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/exception/ManagerSaveException.java
+++ b/src/main/java/io/github/akuniutka/kanban/exception/ManagerSaveException.java
@@ -1,0 +1,9 @@
+package io.github.akuniutka.kanban.exception;
+
+import java.io.IOException;
+
+public class ManagerSaveException extends ManagerException {
+    public ManagerSaveException(String message, IOException cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/model/TaskType.java
+++ b/src/main/java/io/github/akuniutka/kanban/model/TaskType.java
@@ -1,0 +1,7 @@
+package io.github.akuniutka.kanban.model;
+
+public enum TaskType {
+    TASK,
+    EPIC,
+    SUBTASK
+}

--- a/src/main/java/io/github/akuniutka/kanban/service/FileBackedTaskManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/FileBackedTaskManager.java
@@ -1,0 +1,300 @@
+package io.github.akuniutka.kanban.service;
+
+import io.github.akuniutka.kanban.exception.CSVParsingException;
+import io.github.akuniutka.kanban.exception.ManagerLoadException;
+import io.github.akuniutka.kanban.exception.ManagerNoSuchEpicException;
+import io.github.akuniutka.kanban.exception.ManagerSaveException;
+import io.github.akuniutka.kanban.model.*;
+import io.github.akuniutka.kanban.util.CSVLineParser;
+import io.github.akuniutka.kanban.util.CSVToken;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+public class FileBackedTaskManager extends InMemoryTaskManager {
+    private static final String FILE_HEADER = "id,type,name,status,description,epic";
+    private File datafile;
+
+    public FileBackedTaskManager(File file, HistoryManager historyManager) {
+        this(historyManager);
+        this.datafile = file;
+        save();
+    }
+
+    private FileBackedTaskManager(HistoryManager historyManager) {
+        super(historyManager);
+    }
+
+    public static FileBackedTaskManager loadFromFile(File file, HistoryManager historyManager) {
+        FileBackedTaskManager manager = new FileBackedTaskManager(historyManager);
+        manager.datafile = file;
+        manager.load();
+        manager.save();
+        return manager;
+    }
+
+    @Override
+    public void removeTasks() {
+        super.removeTasks();
+        save();
+    }
+
+    @Override
+    public long addTask(Task task) {
+        final long taskId = super.addTask(task);
+        save();
+        return taskId;
+    }
+
+    @Override
+    public void updateTask(Task task) {
+        super.updateTask(task);
+        save();
+    }
+
+    @Override
+    public void removeTask(long id) {
+        super.removeTask(id);
+        save();
+    }
+
+    @Override
+    public void removeEpics() {
+        super.removeEpics();
+        save();
+    }
+
+    @Override
+    public long addEpic(Epic epic) {
+        final long epicId = super.addEpic(epic);
+        save();
+        return epicId;
+    }
+
+    @Override
+    public void updateEpic(Epic epic) {
+        super.updateEpic(epic);
+        save();
+    }
+
+    @Override
+    public void removeEpic(long id) {
+        super.removeEpic(id);
+        save();
+    }
+
+    @Override
+    public void removeSubtasks() {
+        super.removeSubtasks();
+        save();
+    }
+
+    @Override
+    public long addSubtask(Subtask subtask) {
+        final long subtaskId = super.addSubtask(subtask);
+        save();
+        return subtaskId;
+    }
+
+    @Override
+    public void updateSubtask(Subtask subtask) {
+        super.updateSubtask(subtask);
+        save();
+    }
+
+    @Override
+    public void removeSubtask(long id) {
+        super.removeSubtask(id);
+        save();
+    }
+
+    private void save() {
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(datafile, StandardCharsets.UTF_8))) {
+            out.write("lastUsedId=%d%n%s%n".formatted(lastUsedId, FILE_HEADER));
+            for (Task task : tasks.values()) {
+                out.write(toString(task));
+                out.newLine();
+            }
+            for (Epic epic : epics.values()) {
+                out.write(toString(epic));
+                out.newLine();
+            }
+            for (Subtask subtask : subtasks.values()) {
+                out.write(toString(subtask));
+                out.newLine();
+            }
+        } catch (IOException exception) {
+            throw new ManagerSaveException("cannot write to file \"%s\"".formatted(datafile), exception);
+        }
+    }
+
+    private String toString(Task task) {
+        String string = task.getId().toString();
+        if (task instanceof Epic) {
+            string += ",EPIC";
+        } else if (task instanceof Subtask) {
+            string += ",SUBTASK";
+        } else {
+            string += ",TASK";
+        }
+        if (task.getTitle() == null) {
+            string += ",null";
+        } else {
+            string += ",\"" + task.getTitle() + "\"";
+        }
+        if (task instanceof Epic) {
+            string += ",";
+        } else {
+            string += "," + task.getStatus();
+        }
+        if (task.getDescription() == null) {
+            string += ",null";
+        } else {
+            string += ",\"" + task.getDescription() + "\"";
+        }
+        if (task instanceof Subtask subtask) {
+            string += "," + subtask.getEpicId();
+        } else {
+            string += ",";
+        }
+        return string;
+    }
+
+    private void load() {
+        int curLine = 1;
+        try (BufferedReader in = new BufferedReader(new FileReader(datafile, StandardCharsets.UTF_8))) {
+            lastUsedId = extractLastUsedId(in.readLine());
+            curLine++;
+            checkFileHeader(in.readLine());
+            while (in.ready()) {
+                curLine++;
+                String line = in.readLine();
+                final Task task = fromString(line);
+                checkIdForDuplicates(task.getId());
+                try {
+                    if (task instanceof Subtask subtask) {
+                        saveSubtaskAndLinkToEpic(subtask);
+                    } else if (task instanceof Epic epic) {
+                        epics.put(epic.getId(), epic);
+                    } else {
+                        tasks.put(task.getId(), task);
+                    }
+                } catch (ManagerNoSuchEpicException exception) {
+                    throw new CSVParsingException(exception.getMessage(), line.lastIndexOf(",") + 2);
+                }
+            }
+        } catch (CSVParsingException exception) {
+            String message = "%s (%s:%d:%d)".formatted(exception.getShortMessage(), datafile, curLine,
+                    exception.getPositionInLine());
+            throw new ManagerLoadException(message);
+        } catch (IOException exception) {
+            throw new ManagerLoadException("cannot load from file \"%s\"".formatted(datafile), exception);
+        }
+    }
+
+    private long extractLastUsedId(String lastUsedIdString) {
+        if (lastUsedIdString == null || !lastUsedIdString.startsWith("lastUsedId")) {
+            throw new CSVParsingException("\"lastUsedId\" expected", 1);
+        }
+        if (lastUsedIdString.charAt(10) != '=') {
+            throw new CSVParsingException("\"=\" expected", 11);
+        }
+        try {
+            return Long.parseLong(lastUsedIdString.substring(11));
+        } catch (NumberFormatException exception) {
+            throw new CSVParsingException("number expected", 12);
+        }
+    }
+
+    private void checkFileHeader(String header) {
+        if (header == null || !header.startsWith("id")) {
+            throw new CSVParsingException("\"id\" expected", 1);
+        }
+        String[] columnNames = {"type", "name", "status", "description", "epic"};
+        int[] columnStarts = {3, 8, 13, 20, 32};
+        for (int i = 0; i < columnNames.length; i++) {
+            if (header.length() < columnStarts[i] || header.charAt(columnStarts[i] - 1) != ',') {
+                throw new CSVParsingException("comma expected", columnStarts[i]);
+            }
+            if (header.indexOf(columnNames[i], columnStarts[i]) != columnStarts[i]) {
+                throw new CSVParsingException('"' + columnNames[i] + "\" expected", columnStarts[i] + 1);
+            }
+        }
+        if (header.length() > FILE_HEADER.length()) {
+            throw new CSVParsingException("unexpected data", FILE_HEADER.length() + 1);
+        }
+    }
+
+    private Task fromString(String taskString) {
+        CSVLineParser parser = new CSVLineParser(taskString);
+        final long id = extractId(parser.next());
+        final TaskType type = extractType(parser.next());
+        final Task task = switch (type) {
+            case TASK -> new Task();
+            case EPIC -> new Epic();
+            case SUBTASK -> new Subtask();
+        };
+        task.setId(id);
+        task.setTitle(extractText(parser.next()));
+        CSVToken token = parser.next();
+        if (type != TaskType.EPIC) {
+            task.setStatus(extractStatus(token));
+        } else if (!token.value().isEmpty()) {
+            throw new CSVParsingException("explicit epic status", token.position() + 1);
+        }
+        task.setDescription(extractText(parser.next()));
+        token = parser.next();
+        if (task instanceof Subtask subtask) {
+            subtask.setEpicId(extractId(token));
+        } else if (!token.value().isEmpty()) {
+            throw new CSVParsingException("unexpected data", token.position() + 1);
+        }
+        if (parser.hasNext()) {
+            throw new CSVParsingException("unexpected data", token.position() + token.value().length() + 1);
+        }
+        return task;
+    }
+
+    private TaskType extractType(CSVToken token) {
+        try {
+            return TaskType.valueOf(token.value());
+        } catch (IllegalArgumentException exception) {
+            throw new CSVParsingException("unknown task type", token.position() + 1);
+        }
+    }
+
+    private TaskStatus extractStatus(CSVToken token) {
+        if ("null".equals(token.value())) {
+            return null;
+        }
+        try {
+            return TaskStatus.valueOf(token.value());
+        } catch (IllegalArgumentException exception) {
+            throw new CSVParsingException("unknown task status", token.position() + 1);
+        }
+    }
+
+    private long extractId(CSVToken token) {
+        try {
+            return Long.parseLong(token.value());
+        } catch (NumberFormatException exception) {
+            throw new CSVParsingException("number expected", token.position() + 1);
+        }
+    }
+
+    private String extractText(CSVToken token) {
+        if ("null".equals(token.value())) {
+            return null;
+        }
+        if (!token.isQuoted()) {
+            throw new CSVParsingException("text value must be inside double quotes", token.position() + 1);
+        }
+        return token.value();
+    }
+
+    private void checkIdForDuplicates(long id) {
+        if (tasks.containsKey(id) || epics.containsKey(id) || subtasks.containsKey(id)) {
+            throw new CSVParsingException("duplicate task id", 1);
+        }
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
@@ -2,10 +2,7 @@ package io.github.akuniutka.kanban.service;
 
 import io.github.akuniutka.kanban.model.Task;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class InMemoryHistoryManager implements HistoryManager {
     private final Map<Long, Node> history;
@@ -18,9 +15,7 @@ public class InMemoryHistoryManager implements HistoryManager {
 
     @Override
     public void add(Task task) {
-        if (task == null) {
-            throw new NullPointerException("cannot add null to visited tasks history");
-        }
+        Objects.requireNonNull(task, "cannot add null to visited tasks history");
         final long id = task.getId();
         remove(id);
         final Node newNode = linkLast(task);

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
@@ -16,7 +16,7 @@ public class InMemoryHistoryManager implements HistoryManager {
     @Override
     public void add(Task task) {
         Objects.requireNonNull(task, "cannot add null to visited tasks history");
-        final long id = task.getId();
+        final long id = Objects.requireNonNull(task.getId(), "cannot add task with null id to visited tasks history");
         remove(id);
         final Node newNode = linkLast(task);
         history.put(id, newNode);

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryHistoryManager.java
@@ -19,7 +19,7 @@ public class InMemoryHistoryManager implements HistoryManager {
     @Override
     public void add(Task task) {
         if (task == null) {
-            return;
+            throw new NullPointerException("cannot add null to visited tasks history");
         }
         final long id = task.getId();
         remove(id);

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
@@ -46,9 +46,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public long addTask(Task task) {
-        if (task == null) {
-            throw new NullPointerException("cannot add null to list of tasks");
-        }
+        Objects.requireNonNull(task, "cannot add null to list of tasks");
         final long id = generateId();
         task.setId(id);
         tasks.put(id, task);
@@ -57,9 +55,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void updateTask(Task task) {
-        if (task == null) {
-            throw new NullPointerException("cannot apply null update to task");
-        }
+        Objects.requireNonNull(task, "cannot apply null update to task");
         final Long id = task.getId();
         if (!tasks.containsKey(id)) {
             throw new NoSuchElementException("no task with id=" + id);
@@ -102,9 +98,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public long addEpic(Epic epic) {
-        if (epic == null) {
-            throw new NullPointerException("cannot add null to list of epics");
-        }
+        Objects.requireNonNull(epic, "cannot add null to list of epics");
         final long id = generateId();
         epic.setId(id);
         epic.getSubtaskIds().clear();
@@ -115,9 +109,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void updateEpic(Epic epic) {
-        if (epic == null) {
-            throw new NullPointerException("cannot apply null update to epic");
-        }
+        Objects.requireNonNull(epic, "cannot apply null update to epic");
         final Long id = epic.getId();
         final Epic savedEpic = epics.get(id);
         if (savedEpic == null) {
@@ -170,9 +162,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public long addSubtask(Subtask subtask) {
-        if (subtask == null) {
-            throw new NullPointerException("cannot add null to list of subtasks");
-        }
+        Objects.requireNonNull(subtask, "cannot add null to list of subtasks");
         final Long epicId = subtask.getEpicId();
         final Epic epic = epics.get(epicId);
         if (epic == null) {
@@ -188,9 +178,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void updateSubtask(Subtask subtask) {
-        if (subtask == null) {
-            throw new NullPointerException("cannot apply null update to subtask");
-        }
+        Objects.requireNonNull(subtask, "cannot apply null update to subtask");
         final Long id = subtask.getId();
         final Subtask savedSubtask = subtasks.get(id);
         if (savedSubtask == null) {

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
@@ -1,5 +1,8 @@
 package io.github.akuniutka.kanban.service;
 
+import io.github.akuniutka.kanban.exception.ManagerNoSuchEpicException;
+import io.github.akuniutka.kanban.exception.ManagerNoSuchSubtaskException;
+import io.github.akuniutka.kanban.exception.ManagerNoSuchTaskException;
 import io.github.akuniutka.kanban.model.Epic;
 import io.github.akuniutka.kanban.model.Subtask;
 import io.github.akuniutka.kanban.model.Task;
@@ -231,7 +234,7 @@ public class InMemoryTaskManager implements TaskManager {
     protected Task requireTaskExists(Long id) {
         final Task task = tasks.get(id);
         if (task == null) {
-            throw new NoSuchElementException("no task with id=" + id);
+            throw new ManagerNoSuchTaskException("no task with id=" + id);
         }
         return task;
     }
@@ -239,7 +242,7 @@ public class InMemoryTaskManager implements TaskManager {
     protected Epic requireEpicExists(Long id) {
         final Epic epic = epics.get(id);
         if (epic == null) {
-            throw new NoSuchElementException("no epic with id=" + id);
+            throw new ManagerNoSuchEpicException("no epic with id=" + id);
         }
         return epic;
     }
@@ -247,7 +250,7 @@ public class InMemoryTaskManager implements TaskManager {
     protected Subtask requireSubtaskExists(Long id) {
         final Subtask subtask = subtasks.get(id);
         if (subtask == null) {
-            throw new NoSuchElementException("no subtask with id=" + id);
+            throw new ManagerNoSuchSubtaskException("no subtask with id=" + id);
         }
         return subtask;
     }

--- a/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/InMemoryTaskManager.java
@@ -5,14 +5,9 @@ import io.github.akuniutka.kanban.model.Subtask;
 import io.github.akuniutka.kanban.model.Task;
 import io.github.akuniutka.kanban.model.TaskStatus;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class InMemoryTaskManager implements TaskManager {
-    private static final int OK = 0;
-    private static final int WRONG_ARGUMENT = -1;
     private final Map<Long, Task> tasks;
     private final Map<Long, Subtask> subtasks;
     private final Map<Long, Epic> epics;
@@ -52,7 +47,7 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public long addTask(Task task) {
         if (task == null) {
-            return WRONG_ARGUMENT;
+            throw new NullPointerException("cannot add null to list of tasks");
         }
         final long id = generateId();
         task.setId(id);
@@ -61,13 +56,15 @@ public class InMemoryTaskManager implements TaskManager {
     }
 
     @Override
-    public int updateTask(Task task) {
-        if (task == null || !tasks.containsKey(task.getId())) {
-            return WRONG_ARGUMENT;
+    public void updateTask(Task task) {
+        if (task == null) {
+            throw new NullPointerException("cannot apply null update to task");
         }
-        final long id = task.getId();
+        final Long id = task.getId();
+        if (!tasks.containsKey(id)) {
+            throw new NoSuchElementException("no task with id=" + id);
+        }
         tasks.put(id, task);
-        return OK;
     }
 
     @Override
@@ -106,7 +103,7 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public long addEpic(Epic epic) {
         if (epic == null) {
-            return WRONG_ARGUMENT;
+            throw new NullPointerException("cannot add null to list of epics");
         }
         final long id = generateId();
         epic.setId(id);
@@ -117,21 +114,20 @@ public class InMemoryTaskManager implements TaskManager {
     }
 
     @Override
-    public int updateEpic(Epic epic) {
+    public void updateEpic(Epic epic) {
         if (epic == null) {
-            return WRONG_ARGUMENT;
+            throw new NullPointerException("cannot apply null update to epic");
         }
         final Long id = epic.getId();
         final Epic savedEpic = epics.get(id);
         if (savedEpic == null) {
-            return WRONG_ARGUMENT;
+            throw new NoSuchElementException("no epic with id=" + id);
         }
         final List<Long> subtaskIds = savedEpic.getSubtaskIds();
         final TaskStatus status = savedEpic.getStatus();
         epic.setSubtaskIds(subtaskIds);
         epic.setStatus(status);
         epics.put(id, epic);
-        return OK;
     }
 
     @Override
@@ -175,12 +171,12 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public long addSubtask(Subtask subtask) {
         if (subtask == null) {
-            return WRONG_ARGUMENT;
+            throw new NullPointerException("cannot add null to list of subtasks");
         }
         final Long epicId = subtask.getEpicId();
         final Epic epic = epics.get(epicId);
         if (epic == null) {
-            return WRONG_ARGUMENT;
+            throw new NoSuchElementException("no epic with id=" + epicId);
         }
         final long id = generateId();
         subtask.setId(id);
@@ -191,21 +187,20 @@ public class InMemoryTaskManager implements TaskManager {
     }
 
     @Override
-    public int updateSubtask(Subtask subtask) {
+    public void updateSubtask(Subtask subtask) {
         if (subtask == null) {
-            return WRONG_ARGUMENT;
+            throw new NullPointerException("cannot apply null update to subtask");
         }
         final Long id = subtask.getId();
         final Subtask savedSubtask = subtasks.get(id);
         if (savedSubtask == null) {
-            return WRONG_ARGUMENT;
+            throw new NoSuchElementException("no subtask with id=" + id);
         }
         final Long epicId = savedSubtask.getEpicId();
         final Epic epic = epics.get(epicId);
         subtask.setEpicId(epicId);
         subtasks.put(id, subtask);
         updateEpicStatus(epic);
-        return OK;
     }
 
     @Override

--- a/src/main/java/io/github/akuniutka/kanban/service/TaskManager.java
+++ b/src/main/java/io/github/akuniutka/kanban/service/TaskManager.java
@@ -15,7 +15,7 @@ public interface TaskManager {
 
     long addTask(Task task);
 
-    int updateTask(Task task);
+    void updateTask(Task task);
 
     void removeTask(long id);
 
@@ -27,7 +27,7 @@ public interface TaskManager {
 
     long addEpic(Epic epic);
 
-    int updateEpic(Epic epic);
+    void updateEpic(Epic epic);
 
     void removeEpic(long id);
 
@@ -39,7 +39,7 @@ public interface TaskManager {
 
     long addSubtask(Subtask subtask);
 
-    int updateSubtask(Subtask subtask);
+    void updateSubtask(Subtask subtask);
 
     void removeSubtask(long id);
 

--- a/src/main/java/io/github/akuniutka/kanban/util/CSVLineParser.java
+++ b/src/main/java/io/github/akuniutka/kanban/util/CSVLineParser.java
@@ -1,0 +1,53 @@
+package io.github.akuniutka.kanban.util;
+
+import io.github.akuniutka.kanban.exception.CSVParsingException;
+
+import java.util.Objects;
+
+public class CSVLineParser {
+    private final String line;
+    private int prevDelimiterAt;
+
+    public CSVLineParser(String line) {
+        Objects.requireNonNull(line, "cannot parse null string");
+        this.line = line;
+        this.prevDelimiterAt = -1;
+    }
+
+    public boolean hasNext() {
+        return prevDelimiterAt != line.length();
+    }
+
+    public CSVToken next() {
+        if (!hasNext()) {
+            throw new CSVParsingException("unexpected end of line", prevDelimiterAt + 1);
+        }
+        int startIndex = prevDelimiterAt + 1;
+        boolean isQuoted = false;
+        if (line.length() > startIndex && line.charAt(startIndex) == '"') {
+            isQuoted = true;
+            prevDelimiterAt = line.indexOf('"', startIndex + 1);
+            if (prevDelimiterAt == -1) {
+                throw new CSVParsingException("double quote expected", line.length() + 1);
+            }
+            prevDelimiterAt++;
+            if (prevDelimiterAt != line.length() && line.charAt(prevDelimiterAt) != ',') {
+                throw new CSVParsingException("comma expected", prevDelimiterAt + 1);
+            }
+        } else {
+            prevDelimiterAt = line.indexOf(',', startIndex);
+            if (prevDelimiterAt == -1) {
+                prevDelimiterAt = line.length();
+            }
+            int doubleQuoteIndex = line.indexOf('"', startIndex);
+            if (doubleQuoteIndex != -1 && doubleQuoteIndex < prevDelimiterAt) {
+                throw new CSVParsingException("unexpected double quote", doubleQuoteIndex + 1);
+            }
+        }
+        if (isQuoted) {
+            return new CSVToken(startIndex, line.substring(startIndex + 1, prevDelimiterAt - 1), true);
+        } else {
+            return new CSVToken(startIndex, line.substring(startIndex, prevDelimiterAt), false);
+        }
+    }
+}

--- a/src/main/java/io/github/akuniutka/kanban/util/CSVToken.java
+++ b/src/main/java/io/github/akuniutka/kanban/util/CSVToken.java
@@ -1,0 +1,4 @@
+package io.github.akuniutka.kanban.util;
+
+public record CSVToken(int position, String value, boolean isQuoted) {
+}

--- a/test/java/io/github/akuniutka/kanban/service/FileBackedTaskManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/FileBackedTaskManagerTest.java
@@ -1,0 +1,1206 @@
+package io.github.akuniutka.kanban.service;
+
+import io.github.akuniutka.kanban.exception.ManagerLoadException;
+import io.github.akuniutka.kanban.exception.ManagerSaveException;
+import io.github.akuniutka.kanban.model.Epic;
+import io.github.akuniutka.kanban.model.Subtask;
+import io.github.akuniutka.kanban.model.Task;
+import io.github.akuniutka.kanban.model.TaskStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import static io.github.akuniutka.kanban.TestModels.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileBackedTaskManagerTest {
+    private static final String FILE_HEADER = "id,type,name,status,description,epic";
+    private static final String WRONG_FILE_FORMAT = "wrong file format";
+    private static final String WRONG_EXCEPTION_MESSAGE = "message for exception is wrong";
+    private TaskManager manager;
+    private File file;
+    private HistoryManager historyManager;
+    private Task emptyTask;
+    private Task testTask;
+    private Task modifiedTestTask;
+    private Epic emptyEpic;
+    private Epic testEpic;
+    private Epic modifiedTestEpic;
+    private Subtask emptySubtask;
+    private Subtask testSubtask;
+    private Subtask modifiedTestSubtask;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        historyManager = new InMemoryHistoryManager();
+        file = File.createTempFile("kanban", null);
+        manager = new FileBackedTaskManager(file, historyManager);
+        emptyTask = createTestTask();
+        testTask = createTestTask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+        modifiedTestTask = createTestTask(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION, MODIFIED_TEST_STATUS);
+        emptyEpic = createTestEpic();
+        testEpic = createTestEpic(TEST_TITLE, TEST_DESCRIPTION);
+        modifiedTestEpic = createTestEpic(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION);
+        emptySubtask = createTestSubtask();
+        testSubtask = createTestSubtask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+        modifiedTestSubtask = createTestSubtask(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION, MODIFIED_TEST_STATUS);
+    }
+
+    @Test
+    public void shouldCreateFileBackedTaskManagerOfInterfaceType() {
+        assertNotNull(manager, "task manager was not created");
+    }
+
+    @Test
+    public void shouldImmediatelyThrowWhenCannotInitializeDataFile() {
+        String filename = ".";
+        String expectedMessage = "cannot write to file \"" + filename + "\"";
+
+        Exception exception = assertThrows(ManagerSaveException.class,
+                () -> new FileBackedTaskManager(new File(filename), historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldSaveWhenNewTaskAdded() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,TASK,"%s",%s,"%s",
+                """.formatted(FILE_HEADER, testTask.getTitle(), testTask.getStatus(), testTask.getDescription());
+
+        long id = manager.addTask(testTask);
+
+        expectedString = expectedString.formatted(id, id);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenTaskUpdated() throws IOException {
+        long id = manager.addTask(testTask);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                %d,TASK,"%s",%s,"%s",
+                """.formatted(id, FILE_HEADER, id, modifiedTestTask.getTitle(), modifiedTestTask.getStatus(),
+                modifiedTestTask.getDescription());
+        modifiedTestTask.setId(id);
+
+        manager.updateTask(modifiedTestTask);
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldCorrectlySaveTaskWithNullFields() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,TASK,null,null,null,
+                """.formatted(FILE_HEADER);
+
+        long id = manager.addTask(emptyTask);
+
+        expectedString = expectedString.formatted(id, id);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenTaskRemoved() throws IOException {
+        long id = manager.addTask(testTask);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                """.formatted(id, FILE_HEADER);
+
+        manager.removeTask(id);
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenNewEpicAdded() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription());
+
+        long id = manager.addEpic(testEpic);
+
+        expectedString = expectedString.formatted(id, id);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenEpicUpdated() throws IOException {
+        long id = manager.addEpic(testEpic);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                %d,EPIC,"%s",,"%s",
+                """.formatted(id, FILE_HEADER, id, modifiedTestEpic.getTitle(), modifiedTestEpic.getDescription());
+        modifiedTestEpic.setId(id);
+
+        manager.updateEpic(modifiedTestEpic);
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldCorrectlySaveEpicWithNullFields() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,null,,null,
+                """.formatted(FILE_HEADER);
+
+        long id = manager.addEpic(emptyEpic);
+
+        expectedString = expectedString.formatted(id, id);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenEpicRemoved() throws IOException {
+        long id = manager.addEpic(testEpic);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                """.formatted(id, FILE_HEADER);
+
+        manager.removeEpic(id);
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenNewSubtaskAdded() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                %%d,SUBTASK,"%s",%s,"%s",%%d
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription(), testSubtask.getTitle(),
+                testSubtask.getStatus(), testSubtask.getDescription());
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+
+        long subtaskId = manager.addSubtask(testSubtask);
+
+        expectedString = expectedString.formatted(subtaskId, epicId, subtaskId, epicId);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenSubtaskUpdated() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                %%d,SUBTASK,"%s",%s,"%s",%%d
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription(),
+                modifiedTestSubtask.getTitle(), modifiedTestSubtask.getStatus(), modifiedTestSubtask.getDescription());
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        long subtaskId = manager.addSubtask(testSubtask);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setId(subtaskId);
+
+        manager.updateSubtask(modifiedTestSubtask);
+
+        expectedString = expectedString.formatted(subtaskId, epicId, subtaskId, epicId);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldCorrectlySaveSubtaskWithNullFields() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                %%d,SUBTASK,null,null,null,%%d
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription());
+        long epicId = manager.addEpic(testEpic);
+        emptySubtask.setEpicId(epicId);
+
+        long subtaskId = manager.addSubtask(emptySubtask);
+
+        expectedString = expectedString.formatted(subtaskId, epicId, subtaskId, epicId);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenSubtaskRemoved() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription());
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        long subtaskId = manager.addSubtask(testSubtask);
+
+        manager.removeSubtask(subtaskId);
+
+        expectedString = expectedString.formatted(subtaskId, epicId);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenAllTasksRemoved() throws IOException {
+        manager.addTask(testTask);
+        long id = manager.addTask(modifiedTestTask);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                """.formatted(id, FILE_HEADER);
+
+        manager.removeTasks();
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenAllEpicsRemoved() throws IOException {
+        manager.addEpic(testEpic);
+        long id = manager.addEpic(modifiedTestEpic);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                """.formatted(id, FILE_HEADER);
+
+        manager.removeEpics();
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldSaveWhenAllSubtasksRemoved() throws IOException {
+        String expectedString = """
+                lastUsedId=%%d
+                %s
+                %%d,EPIC,"%s",,"%s",
+                """.formatted(FILE_HEADER, testEpic.getTitle(), testEpic.getDescription());
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        manager.addSubtask(testSubtask);
+        modifiedTestSubtask.setEpicId(epicId);
+        long subtaskId = manager.addSubtask(modifiedTestSubtask);
+
+        manager.removeSubtasks();
+
+        expectedString = expectedString.formatted(subtaskId, epicId);
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldCorrectlySaveLastUsedId() throws IOException {
+        long id = manager.addTask(testTask);
+        String expectedString = """
+                lastUsedId=%d
+                %s
+                """.formatted(id, FILE_HEADER);
+
+        manager.removeTask(id);
+
+        String actualString = Files.readString(file.toPath());
+        assertEquals(expectedString, actualString, WRONG_FILE_FORMAT);
+    }
+
+    @Test
+    public void shouldLoadTaskFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1
+                id,type,name,status,description,epic
+                1,TASK,"Title",IN_PROGRESS,"Description",
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Task> tasks = manager.getTasks();
+        assertEquals(1, tasks.size(), "list should contain exactly 1 element");
+        assertEquals(Task.class, tasks.getFirst().getClass(), "element in list should be of Task class");
+        Task task = tasks.getFirst();
+        assertEquals(TEST_TASK_ID, task.getId(), "task id loaded incorrectly");
+        assertEquals(TEST_TITLE, task.getTitle(), "task title loaded incorrectly");
+        assertEquals(TEST_DESCRIPTION, task.getDescription(), "task description loaded incorrectly");
+        assertEquals(TEST_STATUS, task.getStatus(), "task status loaded incorrectly");
+    }
+
+    @Test
+    public void shouldLoadTaskWithNullFieldsFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1
+                id,type,name,status,description,epic
+                1,TASK,null,null,null,
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Task> tasks = manager.getTasks();
+        assertEquals(1, tasks.size(), "list should contain exactly 1 element");
+        assertEquals(Task.class, tasks.getFirst().getClass(), "element in list should be of Task class");
+        Task task = tasks.getFirst();
+        assertEquals(TEST_TASK_ID, task.getId(), "task id loaded incorrectly");
+        assertNull(task.getTitle(), "task title loaded incorrectly");
+        assertNull(task.getDescription(), "task description loaded incorrectly");
+        assertNull(task.getStatus(), "task status loaded incorrectly");
+    }
+
+    @Test
+    public void shouldLoadEpicFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=2
+                id,type,name,status,description,epic
+                2,EPIC,"Title",,"Description",
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Epic> epics = manager.getEpics();
+        assertEquals(1, epics.size(), "list should contain exactly 1 element");
+        assertEquals(Epic.class, epics.getFirst().getClass(), "element in list should be of Epic class");
+        Epic epic = epics.getFirst();
+        assertEquals(TEST_EPIC_ID, epic.getId(), "epic id loaded incorrectly");
+        assertEquals(TEST_TITLE, epic.getTitle(), "epic title loaded incorrectly");
+        assertEquals(TEST_DESCRIPTION, epic.getDescription(), "epic description loaded incorrectly");
+        assertTrue(epic.getSubtaskIds().isEmpty(), "list of epic subtasks should be empty");
+    }
+
+    @Test
+    public void shouldLoadEpicWithNullFieldsFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=2
+                id,type,name,status,description,epic
+                2,EPIC,null,,null,
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Epic> epics = manager.getEpics();
+        assertEquals(1, epics.size(), "list should contain exactly 1 element");
+        assertEquals(Epic.class, epics.getFirst().getClass(), "element in list should be of Epic class");
+        Epic epic = epics.getFirst();
+        assertEquals(TEST_EPIC_ID, epic.getId(), "epic id loaded incorrectly");
+        assertNull(epic.getTitle(), "epic title loaded incorrectly");
+        assertNull(epic.getDescription(), "epic description loaded incorrectly");
+        assertTrue(epic.getSubtaskIds().isEmpty(), "list of epic subtasks should be empty");
+    }
+
+    @Test
+    public void shouldLoadSubtaskFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=3
+                id,type,name,status,description,epic
+                2,EPIC,"Title",,"Description",
+                3,SUBTASK,"Title",IN_PROGRESS,"Description",2
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Subtask> subtasks = manager.getSubtasks();
+        assertEquals(1, subtasks.size(), "list should contain exactly 1 element");
+        assertEquals(Subtask.class, subtasks.getFirst().getClass(), "element in list should be of Subtask class");
+        Subtask subtask = subtasks.getFirst();
+        assertEquals(TEST_SUBTASK_ID, subtask.getId(), "subtask id loaded incorrectly");
+        assertEquals(TEST_EPIC_ID, subtask.getEpicId(), "epic id of subtask loaded incorrectly");
+        assertEquals(TEST_TITLE, subtask.getTitle(), "subtask title loaded incorrectly");
+        assertEquals(TEST_DESCRIPTION, subtask.getDescription(), "subtask description loaded incorrectly");
+        assertEquals(TEST_STATUS, subtask.getStatus(), "subtask status loaded incorrectly");
+        Epic epic = manager.getEpics().getFirst();
+        assertEquals(1, epic.getSubtaskIds().size(), "list of epic subtasks should contain exactly 1 element");
+        assertEquals(TEST_SUBTASK_ID, epic.getSubtaskIds().getFirst(), "subtask id loaded incorrectly");
+    }
+
+    @Test
+    public void shouldLoadSubtaskWithNullFieldsFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=3
+                id,type,name,status,description,epic
+                2,EPIC,"Title",,"Description",
+                3,SUBTASK,null,null,null,2
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Subtask> subtasks = manager.getSubtasks();
+        assertEquals(1, subtasks.size(), "list should contain exactly 1 element");
+        assertEquals(Subtask.class, subtasks.getFirst().getClass(), "element in list should be of Subtask class");
+        Subtask subtask = subtasks.getFirst();
+        assertEquals(TEST_SUBTASK_ID, subtask.getId(), "subtask id loaded incorrectly");
+        assertEquals(TEST_EPIC_ID, subtask.getEpicId(), "epic id of subtask loaded incorrectly");
+        assertNull(subtask.getTitle(), "subtask title loaded incorrectly");
+        assertNull(subtask.getDescription(), "subtask description loaded incorrectly");
+        assertNull(subtask.getStatus(), "subtask status loaded incorrectly");
+        Epic epic = manager.getEpics().getFirst();
+        assertEquals(1, epic.getSubtaskIds().size(), "list of epic subtasks should contain exactly 1 element");
+        assertEquals(TEST_SUBTASK_ID, epic.getSubtaskIds().getFirst(), "subtask id loaded incorrectly");
+    }
+
+    @Test
+    public void shouldRecalculateEpicStatusOnLoad() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=10
+                id,type,name,status,description,epic
+                1,EPIC,"Epic 1",,"Epic with no subtasks",
+                2,EPIC,"Epic 2",,"Epic with all subtasks in status NEW",
+                3,EPIC,"Epic 3",,"Epic with all subtasks in status DONE",
+                4,EPIC,"Epic 4",,"Epic with subtasks in different statuses",
+                5,SUBTASK,"Subtask 1",NEW,"Subtask 1 description",2
+                6,SUBTASK,"Subtask 2",NEW,"Subtask 2 description",2
+                7,SUBTASK,"Subtask 3",DONE,"Subtask 3 description",3
+                8,SUBTASK,"Subtask 4",DONE,"Subtask 4 description",3
+                9,SUBTASK,"Subtask 5",NEW,"Subtask 5 description",4
+                10,SUBTASK,"Subtask 6",DONE,"Subtask 6 description",4
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+
+        List<Epic> epics = manager.getEpics();
+        assertEquals(4, epics.size(), "list should contain exactly 4 elements");
+        assertEquals(TaskStatus.NEW, epics.getFirst().getStatus(), "epic should have status NEW");
+        assertEquals(TaskStatus.NEW, epics.get(1).getStatus(), "epic should have status NEW");
+        assertEquals(TaskStatus.DONE, epics.get(2).getStatus(), "epic should have status DONE");
+        assertEquals(TaskStatus.IN_PROGRESS, epics.getLast().getStatus(), "epic should have status IN_PROGRESS");
+    }
+
+    @Test
+    public void shouldLoadLastUsedIdFromFile() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                """);
+
+        manager = FileBackedTaskManager.loadFromFile(file, historyManager);
+        long id = manager.addTask(testTask);
+
+        assertEquals(1001, id, "last used id loaded incorrectly");
+    }
+
+    @Test
+    public void shouldThrowWhenCannotLoadFromFile() {
+        String filename = ".";
+        String expectedMessage = "cannot load from file \"" + filename + "\"";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(new File(filename), historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenFileIsEmpty() throws IOException {
+        file = File.createTempFile("kanban", null);
+        String expectedMessage = "\"lastUsedId\" expected (" + file + ":1:1)";
+
+        ManagerLoadException exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenFileLoadedDoesNotStartWithLastUsedId() throws IOException {
+        file = makeTestFileFromString("""
+                randomText=1000
+                id,type,name,status,description,epic
+                """);
+        String expectedMessage = "\"lastUsedId\" expected (" + file + ":1:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenLastUserIdInFileNotFollowedByEquals() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId:1000
+                id,type,name,status,description,epic
+                """);
+        String expectedMessage = "\"=\" expected (" + file + ":1:11)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenLastUserIdInFileIsNotNumber() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=thousand
+                id,type,name,status,description,epic
+                """);
+        String expectedMessage = "number expected (" + file + ":1:12)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenFileContainsNoHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                """);
+        String expectedMessage = "\"id\" expected (" + file + ":2:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindIdInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                text,type,name,status,description,epic
+                """);
+        String expectedMessage = "\"id\" expected (" + file + ":2:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindFirstCommaInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id:type:name:status:description:epic
+                """);
+        String expectedMessage = "comma expected (" + file + ":2:3)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindTypeInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,text,name,status,description,epic
+                """);
+        String expectedMessage = "\"type\" expected (" + file + ":2:4)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindSecondCommaInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type:name,status,description,epic
+                """);
+        String expectedMessage = "comma expected (" + file + ":2:8)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindNameInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,text,status,description,epic
+                """);
+        String expectedMessage = "\"name\" expected (" + file + ":2:9)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindThirdCommaInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name:status,description,epic
+                """);
+        String expectedMessage = "comma expected (" + file + ":2:13)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindStatusInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,text,description,epic
+                """);
+        String expectedMessage = "\"status\" expected (" + file + ":2:14)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindFourthCommaInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status:description,epic
+                """);
+        String expectedMessage = "comma expected (" + file + ":2:20)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindDescriptionInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,text,epic
+                """);
+        String expectedMessage = "\"description\" expected (" + file + ":2:21)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindFifthCommaInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description:epic
+                """);
+        String expectedMessage = "comma expected (" + file + ":2:32)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenCannotFindEpicInFileHeader() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,text
+                """);
+        String expectedMessage = "\"epic\" expected (" + file + ":2:33)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenFileHeaderHasExcessiveCharacters() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic,
+                """);
+        String expectedMessage = "unexpected data (" + file + ":2:37)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasNotEnoughFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title",IN_PROGRESS,"Description"
+                """);
+        String expectedMessage = "unexpected end of line (" + file + ":3:41)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasNotEnoughFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Title",,"Description"
+                """);
+        String expectedMessage = "unexpected end of line (" + file + ":3:30)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasNotEnoughFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description"
+                """);
+        String expectedMessage = "unexpected end of line (" + file + ":4:46)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasExcessiveFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Task",IN_PROGRESS,"Task description",,
+                """);
+        String expectedMessage = "unexpected data (" + file + ":3:46)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasExcessiveFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",,
+                """);
+        String expectedMessage = "unexpected data (" + file + ":3:35)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasExcessiveFields() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",1,
+                """);
+        String expectedMessage = "unexpected data (" + file + ":4:48)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskIdFromFileNotNumber() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                one,TASK,"Title",IN_PROGRESS,"Description",
+                """);
+        String expectedMessage = "number expected (" + file + ":3:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasUnknownType() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,text,"Title",IN_PROGRESS,"Description",
+                """);
+        String expectedMessage = "unknown task type (" + file + ":3:3)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskTitleFromFileDoesNotStartWithQuote() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,Title",IN_PROGRESS,"Description",
+                """);
+        String expectedMessage = "unexpected double quote (" + file + ":3:13)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskTitleFromFileDoesNotEndWithQuote() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title,IN_PROGRESS,"Description",
+                """);
+        String expectedMessage = "comma expected (" + file + ":3:28)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskTitleFromFileHasNoQuotes() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,Title,IN_PROGRESS,"Description",
+                """);
+        String expectedMessage = "text value must be inside double quotes (" + file + ":3:8)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasUnknownStatus() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title",text,"Description",
+                """);
+        String expectedMessage = "unknown task status (" + file + ":3:16)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasStatus() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Title",DONE,"Description",
+                """);
+        String expectedMessage = "explicit epic status (" + file + ":3:16)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskDescriptionFromFileDoesNotStartWithQuote() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title",IN_PROGRESS,Description",
+                """);
+        String expectedMessage = "unexpected double quote (" + file + ":3:39)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskDescriptionFromFileDoesNotEndWithQuote() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title",IN_PROGRESS,"Description,
+                """);
+        String expectedMessage = "double quote expected (" + file + ":3:41)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskDescriptionFromFileHasNoQuotes() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Title",IN_PROGRESS,Description,
+                """);
+        String expectedMessage = "text value must be inside double quotes (" + file + ":3:28)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,TASK,"Task",IN_PROGRESS,"Task description",1
+                """);
+        String expectedMessage = "unexpected data (" + file + ":4:46)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic A",,"Epic A description",
+                2,EPIC,"Epic B",,"Epic B description",1
+                """);
+        String expectedMessage = "unexpected data (" + file + ":4:39)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasNoEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",
+                """);
+        String expectedMessage = "number expected (" + file + ":4:47)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicIdOfSubtaskFromFileIsNotNumber() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",one
+                """);
+        String expectedMessage = "number expected (" + file + ":4:47)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasUnknownEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",3
+                """);
+        String expectedMessage = "no epic with id=3 (" + file + ":4:47)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasTaskIdAsEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Task",NEW,"Task description",
+                2,EPIC,"Epic",,"Epic description",
+                3,SUBTASK,"Subtask",NEW,"Subtask description",1
+                """);
+        String expectedMessage = "no epic with id=1 (" + file + ":5:47)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasSubtaskIdAsEpicId() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask A",NEW,"Subtask A description",1
+                3,SUBTASK,"Subtask B",NEW,"Subtask B description",2
+                """);
+        String expectedMessage = "no epic with id=2 (" + file + ":5:51)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasIdOfAnotherTask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Task A",NEW,"Task A description",
+                1,TASK,"Task B",NEW,"Task B description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":4:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasIdOfEpic() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                1,TASK,"Task",NEW,"Task description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":4:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenTaskFromFileHasIdOfSubtask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",1
+                2,TASK,"Task",NEW,"Task description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":5:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasIdOfTask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Task",NEW,"Task description",
+                1,EPIC,"Epic",,"Epic description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":4:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasIdOfAnotherEpic() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic A",,"Epic A description",
+                1,EPIC,"Epic B",,"Epic B description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":4:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenEpicFromFileHasIdOfSubtask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic A",,"Epic A description",
+                2,SUBTASK,"Subtask",NEW,"Subtask description",1
+                2,EPIC,"Epic B",,"Epic B description",
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":5:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasIdOfTask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,TASK,"Task",NEW,"Task description",
+                2,EPIC,"Epic",,"Subtask description",
+                1,SUBTASK,"Subtask",NEW,"Subtask description",2
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":5:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasIdOfEpic() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic A",,"Epic A description",
+                2,EPIC,"Epic B",,"Epic B description",
+                1,SUBTASK,"Subtask",NEW,"Subtask description",2
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":5:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenSubtaskFromFileHasIdOfAnotherSubtask() throws IOException {
+        file = makeTestFileFromString("""
+                lastUsedId=1000
+                id,type,name,status,description,epic
+                1,EPIC,"Epic",,"Epic description",
+                2,SUBTASK,"Subtask A",NEW,"Subtask A description",1
+                2,SUBTASK,"Subtask B",NEW,"Subtask B description",1
+                """);
+        String expectedMessage = "duplicate task id (" + file + ":5:1)";
+
+        Exception exception = assertThrows(ManagerLoadException.class,
+                () -> FileBackedTaskManager.loadFromFile(file, historyManager));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    private File makeTestFileFromString(String testData) throws IOException {
+        File testFile = File.createTempFile("kanban", null);
+        Files.writeString(testFile.toPath(), testData, StandardCharsets.UTF_8);
+        return testFile;
+    }
+}

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
@@ -12,6 +12,7 @@ import static io.github.akuniutka.kanban.TestModels.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryHistoryManagerTest {
+    private static final String WRONG_EXCEPTION_MESSAGE = "message for exception is wrong";
     private HistoryManager manager;
     private Task testTask;
     private Task modifiedTestTask;
@@ -43,7 +44,16 @@ class InMemoryHistoryManagerTest {
         String expectedMessage = "cannot add null to visited tasks history";
 
         Exception exception = assertThrows(NullPointerException.class, () -> manager.add(null));
-        assertEquals(expectedMessage, exception.getMessage(), "message for exception is wrong");
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldNotAllowTasksEpicsSubtasksWithNullId() {
+        String expectedMessage = "cannot add task with null id to visited tasks history";
+        Task task = createTestTask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.add(task));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
@@ -40,11 +40,9 @@ class InMemoryHistoryManagerTest {
 
     @Test
     public void shouldNotAllowNullTasksEpicsSubtasks() {
-        manager.add(null);
-        List<Task> tasks = manager.getHistory();
-
-        assertNotNull(tasks, "should return list of tasks");
-        assertTrue(tasks.isEmpty(), "tasks list should be empty");
+        String expectedMessage = "cannot add null to visited tasks history";
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.add(null));
+        assertEquals(expectedMessage, exception.getMessage(), "message for exception is wrong");
     }
 
     @Test

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
@@ -185,7 +185,7 @@ class InMemoryHistoryManagerTest {
         assertEquals(Subtask.class, tasks.getFirst().getClass(), "element in list should be of Subtask class");
         Subtask savedSubtask = (Subtask) tasks.getFirst();
         assertEquals(TEST_SUBTASK_ID, savedSubtask.getId(), "subtask id should not change");
-        assertEquals(TEST_EPIC_ID, savedSubtask.getEpicId(), "epic id of status should not change");
+        assertEquals(TEST_EPIC_ID, savedSubtask.getEpicId(), "epic id of subtask should not change");
         assertEquals(TEST_TITLE, savedSubtask.getTitle(), "subtask title should not change");
         assertEquals(TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description should not change");
         assertEquals(TEST_STATUS, savedSubtask.getStatus(), "subtask status should not change");
@@ -202,7 +202,7 @@ class InMemoryHistoryManagerTest {
         assertEquals(Subtask.class, tasks.getFirst().getClass(), "element in list should be of Subtask class");
         Subtask savedSubtask = (Subtask) tasks.getFirst();
         assertEquals(TEST_SUBTASK_ID, savedSubtask.getId(), "subtask id should not change");
-        assertEquals(TEST_EPIC_ID, savedSubtask.getEpicId(), "epic id of status should not change");
+        assertEquals(TEST_EPIC_ID, savedSubtask.getEpicId(), "epic id of subtask should not change");
         assertEquals(MODIFIED_TEST_TITLE, savedSubtask.getTitle(), "subtask title is not actual");
         assertEquals(MODIFIED_TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description is not actual");
         assertEquals(MODIFIED_TEST_STATUS, savedSubtask.getStatus(), "subtask status is not actual");
@@ -221,7 +221,7 @@ class InMemoryHistoryManagerTest {
         assertEquals(Subtask.class, tasks.getFirst().getClass(), "element in list should be of Subtask class");
         Subtask savedSubtask = (Subtask) tasks.getFirst();
         assertEquals(TEST_SUBTASK_ID, savedSubtask.getId(), "subtask id should not change");
-        assertNull(savedSubtask.getEpicId(), "epic id of status should not change");
+        assertNull(savedSubtask.getEpicId(), "epic id of subtask should not change");
         assertNull(savedSubtask.getTitle(), "subtask title should not change");
         assertNull(savedSubtask.getDescription(), "subtask description should not change");
         assertNull(savedSubtask.getStatus(), "subtask status should not change");
@@ -232,7 +232,7 @@ class InMemoryHistoryManagerTest {
         manager.add(testSubtask);
 
         assertEquals(TEST_SUBTASK_ID, testSubtask.getId(), "subtask id should not change");
-        assertEquals(TEST_EPIC_ID, testSubtask.getEpicId(), "epic id of status should not change");
+        assertEquals(TEST_EPIC_ID, testSubtask.getEpicId(), "epic id of subtask should not change");
         assertEquals(TEST_TITLE, testSubtask.getTitle(), "subtask title should not change");
         assertEquals(TEST_DESCRIPTION, testSubtask.getDescription(), "subtask description should not change");
         assertEquals(TEST_STATUS, testSubtask.getStatus(), "subtask status should not change");

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryHistoryManagerTest.java
@@ -41,6 +41,7 @@ class InMemoryHistoryManagerTest {
     @Test
     public void shouldNotAllowNullTasksEpicsSubtasks() {
         String expectedMessage = "cannot add null to visited tasks history";
+
         Exception exception = assertThrows(NullPointerException.class, () -> manager.add(null));
         assertEquals(expectedMessage, exception.getMessage(), "message for exception is wrong");
     }

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
@@ -1,5 +1,8 @@
 package io.github.akuniutka.kanban.service;
 
+import io.github.akuniutka.kanban.exception.ManagerNoSuchEpicException;
+import io.github.akuniutka.kanban.exception.ManagerNoSuchSubtaskException;
+import io.github.akuniutka.kanban.exception.ManagerNoSuchTaskException;
 import io.github.akuniutka.kanban.model.Epic;
 import io.github.akuniutka.kanban.model.Subtask;
 import io.github.akuniutka.kanban.model.Task;
@@ -11,7 +14,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import static io.github.akuniutka.kanban.TestModels.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -67,7 +69,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no task with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getTask(id));
+        Exception exception = assertThrows(ManagerNoSuchTaskException.class, () -> manager.getTask(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -145,7 +147,7 @@ class InMemoryTaskManagerTest {
     public void shouldNotUpdateTaskWhenIdNotSet() {
         String expectedMessage = "no task with id=null";
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateTask(testTask));
+        Exception exception = assertThrows(ManagerNoSuchTaskException.class, () -> manager.updateTask(testTask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -155,19 +157,18 @@ class InMemoryTaskManagerTest {
         String expectedMessage = "no task with id=" + taskId;
         testTask.setId(taskId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateTask(testTask));
+        Exception exception = assertThrows(ManagerNoSuchTaskException.class, () -> manager.updateTask(testTask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldRemoveTask() {
         long id = manager.addTask(testTask);
-        String expectedMessage = "no task with id=" + id;
 
         manager.removeTask(id);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getTask(id));
-        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertThrows(ManagerNoSuchTaskException.class, () -> manager.getTask(id),
+                "should have no access to removed task");
     }
 
     @Test
@@ -175,7 +176,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no task with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeTask(id));
+        Exception exception = assertThrows(ManagerNoSuchTaskException.class, () -> manager.removeTask(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -195,7 +196,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no epic with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpic(id));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.getEpic(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -269,7 +270,7 @@ class InMemoryTaskManagerTest {
     public void shouldNotUpdateEpicWhenIdNotSet() {
         String expectedMessage = "no epic with id=null";
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateEpic(testEpic));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.updateEpic(testEpic));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -279,7 +280,7 @@ class InMemoryTaskManagerTest {
         String expectedMessage = "no epic with id=" + id;
         testEpic.setId(id);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateEpic(testEpic));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.updateEpic(testEpic));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -514,12 +515,11 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveEpic() {
         long id = manager.addEpic(testEpic);
-        String expectedMessage = "no epic with id=" + id;
 
         manager.removeEpic(id);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpic(id));
-        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertThrows(ManagerNoSuchEpicException.class, () -> manager.getEpic(id),
+                "should have no access to removed epic");
     }
 
     @Test
@@ -527,7 +527,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no epic with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeEpic(id));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.removeEpic(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -552,7 +552,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no subtask with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
+        Exception exception = assertThrows(ManagerNoSuchSubtaskException.class, () -> manager.getSubtask(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -604,7 +604,7 @@ class InMemoryTaskManagerTest {
     public void shouldNotAddSubtaskToNull() {
         String expectedMessage = "no epic with id=null";
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.addSubtask(testSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -614,7 +614,7 @@ class InMemoryTaskManagerTest {
         String expectedMessage = "no epic with id=" + epicId;
         testSubtask.setEpicId(epicId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.addSubtask(testSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -624,7 +624,7 @@ class InMemoryTaskManagerTest {
         String expectedMessage = "no epic with id=" + taskId;
         testSubtask.setEpicId(taskId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.addSubtask(testSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -636,7 +636,8 @@ class InMemoryTaskManagerTest {
         String expectedMessage = "no epic with id=" + subtaskId;
         modifiedTestSubtask.setEpicId(subtaskId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(modifiedTestSubtask));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class,
+                () -> manager.addSubtask(modifiedTestSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -688,7 +689,8 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateSubtask(testSubtask));
+        Exception exception = assertThrows(ManagerNoSuchSubtaskException.class,
+                () -> manager.updateSubtask(testSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -700,7 +702,8 @@ class InMemoryTaskManagerTest {
         testSubtask.setEpicId(epicId);
         testSubtask.setId(id);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateSubtask(testSubtask));
+        Exception exception = assertThrows(ManagerNoSuchSubtaskException.class,
+                () -> manager.updateSubtask(testSubtask));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -709,12 +712,11 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         long id = manager.addSubtask(testSubtask);
-        String expectedMessage = "no subtask with id=" + id;
 
         manager.removeSubtask(id);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
-        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertThrows(ManagerNoSuchSubtaskException.class, () -> manager.getSubtask(id),
+                "should have no access to removed subtask");
     }
 
     @Test
@@ -722,12 +724,11 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         long id = manager.addSubtask(testSubtask);
-        String expectedMessage = "no subtask with id=" + id;
 
         manager.removeEpic(epicId);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
-        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertThrows(ManagerNoSuchSubtaskException.class, () -> manager.getSubtask(id),
+                "should have no access to removed subtask");
     }
 
     @Test
@@ -735,7 +736,7 @@ class InMemoryTaskManagerTest {
         long id = -1L;
         String expectedMessage = "no subtask with id=" + id;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeSubtask(id));
+        Exception exception = assertThrows(ManagerNoSuchSubtaskException.class, () -> manager.removeSubtask(id));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
@@ -764,7 +765,7 @@ class InMemoryTaskManagerTest {
         long epicId = -1L;
         String expectedMessage = "no epic with id=" + epicId;
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpicSubtasks(epicId));
+        Exception exception = assertThrows(ManagerNoSuchEpicException.class, () -> manager.getEpicSubtasks(epicId));
         assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
@@ -63,6 +63,15 @@ class InMemoryTaskManagerTest {
     }
 
     @Test
+    public void shouldThrowWhenRetrievingNonExistingTask() {
+        long id = -1L;
+        String expectedMessage = "no task with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getTask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
     public void shouldAllowAddTaskWithNullFields() {
         long id = manager.addTask(emptyTask);
         Task savedTask = manager.getTask(id);
@@ -153,11 +162,21 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveTask() {
         long id = manager.addTask(testTask);
+        String expectedMessage = "no task with id=" + id;
 
         manager.removeTask(id);
-        Task savedTask = manager.getTask(id);
 
-        assertNull(savedTask, "should have no access to removed task");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getTask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowRemovingNonExistingTask() {
+        long id = -1L;
+        String expectedMessage = "no task with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeTask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -169,6 +188,15 @@ class InMemoryTaskManagerTest {
         assertEquals(id, savedEpic.getId(), "epic id differs from returned by manager");
         assertEquals(TEST_TITLE, savedEpic.getTitle(), "epic title changed");
         assertEquals(TEST_DESCRIPTION, savedEpic.getDescription(), "epic description changed");
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingNonExistingEpic() {
+        long id = -1L;
+        String expectedMessage = "no epic with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpic(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -486,11 +514,21 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveEpic() {
         long id = manager.addEpic(testEpic);
+        String expectedMessage = "no epic with id=" + id;
 
         manager.removeEpic(id);
-        Epic savedEpic = manager.getEpic(id);
 
-        assertNull(savedEpic, "should have no access to removed epic");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpic(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRemovingNonExistingEpic() {
+        long id = -1L;
+        String expectedMessage = "no epic with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeEpic(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -507,6 +545,15 @@ class InMemoryTaskManagerTest {
         assertEquals(TEST_TITLE, savedSubtask.getTitle(), "subtask title changed");
         assertEquals(TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description changed");
         assertEquals(TEST_STATUS, savedSubtask.getStatus(), "subtask status changed");
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingNonExistingSubtask() {
+        long id = -1L;
+        String expectedMessage = "no subtask with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -662,11 +709,12 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         long id = manager.addSubtask(testSubtask);
+        String expectedMessage = "no subtask with id=" + id;
 
         manager.removeSubtask(id);
-        Subtask savedSubtask = manager.getSubtask(id);
 
-        assertNull(savedSubtask, "should have no access to removed subtask");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -674,11 +722,21 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         long id = manager.addSubtask(testSubtask);
+        String expectedMessage = "no subtask with id=" + id;
 
         manager.removeEpic(epicId);
-        Subtask savedSubtask = manager.getSubtask(id);
 
-        assertNull(savedSubtask, "should have no access to subtask of removed epic");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getSubtask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRemovingNonExistingSubtask() {
+        long id = -1L;
+        String expectedMessage = "no subtask with id=" + id;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.removeSubtask(id));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -699,6 +757,15 @@ class InMemoryTaskManagerTest {
         List<Subtask> actualSubtaskList = manager.getEpicSubtasks(epicId);
 
         assertEquals(expectedSubtaskList, actualSubtaskList, "incorrect list of subtasks returned");
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingSubtasksOfNonExistingEpic() {
+        long epicId = -1L;
+        String expectedMessage = "no epic with id=" + epicId;
+
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.getEpicSubtasks(epicId));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static io.github.akuniutka.kanban.TestModels.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryTaskManagerTest {
-    private static final int OK = 0;
-    private static final int WRONG_ARGUMENT = -1;
+    private static final String WRONG_EXCEPTION_MESSAGE = "message for exception is wrong";
     private TaskManager manager;
     private HistoryManager historyManager;
     private Task emptyTask;
@@ -76,9 +76,10 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotAddNullTask() {
-        long id = manager.addTask(null);
+        String expectedMessage = "cannot add null to list of tasks";
 
-        assertEquals(WRONG_ARGUMENT, id, "null task should not be added");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.addTask(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -100,10 +101,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addTask(testTask);
         modifiedTestTask.setId(id);
 
-        int result = manager.updateTask(modifiedTestTask);
+        manager.updateTask(modifiedTestTask);
         Task savedTask = manager.getTask(id);
 
-        assertEquals(OK, result, "should return 0 when processed task update");
         assertEquals(id, savedTask.getId(), "task id changed");
         assertEquals(MODIFIED_TEST_TITLE, savedTask.getTitle(), "task title not updated");
         assertEquals(MODIFIED_TEST_DESCRIPTION, savedTask.getDescription(), "task description not updated");
@@ -115,10 +115,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addTask(testTask);
         emptyTask.setId(id);
 
-        int result = manager.updateTask(emptyTask);
+        manager.updateTask(emptyTask);
         Task savedTask = manager.getTask(id);
 
-        assertEquals(OK, result, "should return 0 when processed task update");
         assertEquals(id, savedTask.getId(), "task id changed");
         assertNull(savedTask.getTitle(), "task title not updated");
         assertNull(savedTask.getDescription(), "task description not updated");
@@ -127,25 +126,28 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotUpdateNullTask() {
-        int result = manager.updateTask(null);
+        String expectedMessage = "cannot apply null update to task";
 
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for null task");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.updateTask(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateTaskWhenIdNotSet() {
-        int result = manager.updateTask(testTask);
+        String expectedMessage = "no task with id=null";
 
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for task with null id");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateTask(testTask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateNonExistingTask() {
-        testTask.setId(-1L);
+        long taskId = -1L;
+        String expectedMessage = "no task with id=" + taskId;
+        testTask.setId(taskId);
 
-        int result = manager.updateTask(testTask);
-
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for unknown task");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateTask(testTask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -182,9 +184,10 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotAddNullEpic() {
-        long id = manager.addEpic(null);
+        String expectedMessage = "cannot add null to list of epics";
 
-        assertEquals(WRONG_ARGUMENT, id, "null epic should not be added");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.addEpic(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -205,10 +208,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addEpic(testEpic);
         modifiedTestEpic.setId(id);
 
-        int result = manager.updateEpic(modifiedTestEpic);
+        manager.updateEpic(modifiedTestEpic);
         Epic savedEpic = manager.getEpic(id);
 
-        assertEquals(OK, result, "should return 0 when processed epic update");
         assertEquals(id, savedEpic.getId(), "epic id changed");
         assertEquals(MODIFIED_TEST_TITLE, savedEpic.getTitle(), "epic title not updated");
         assertEquals(MODIFIED_TEST_DESCRIPTION, savedEpic.getDescription(), "epic description not updated");
@@ -219,10 +221,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addEpic(testEpic);
         emptyEpic.setId(id);
 
-        int result = manager.updateEpic(emptyEpic);
+        manager.updateEpic(emptyEpic);
         Epic savedEpic = manager.getEpic(id);
 
-        assertEquals(OK, result, "should return 0 when processed epic update");
         assertEquals(id, savedEpic.getId(), "epic id changed");
         assertNull(savedEpic.getTitle(), "epic title not updated");
         assertNull(savedEpic.getDescription(), "epic description not updated");
@@ -230,25 +231,28 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotUpdateNullEpic() {
-        int result = manager.updateEpic(null);
+        String expectedMessage = "cannot apply null update to epic";
 
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for null epic");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.updateEpic(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateEpicWhenIdNotSet() {
-        int result = manager.updateEpic(testEpic);
+        String expectedMessage = "no epic with id=null";
 
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for epic with null id");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateEpic(testEpic));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateNonExistingEpic() {
-        testEpic.setId(-1L);
+        long id = -1L;
+        String expectedMessage = "no epic with id=" + id;
+        testEpic.setId(id);
 
-        int result = manager.updateEpic(testEpic);
-
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for unknown epic");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateEpic(testEpic));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @ParameterizedTest
@@ -523,9 +527,10 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotAddNullSubtask() {
-        long id = manager.addSubtask(null);
+        String expectedMessage = "cannot add null to list of subtasks";
 
-        assertEquals(WRONG_ARGUMENT, id, "null subtask should not be added");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.addSubtask(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -550,29 +555,30 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotAddSubtaskToNull() {
-        long id = manager.addSubtask(testSubtask);
+        String expectedMessage = "no epic with id=null";
 
-        assertEquals(WRONG_ARGUMENT, id, "subtask with null epic id should not be added");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotAddSubtaskToNotExistingEpic() {
         long epicId = -1L;
+        String expectedMessage = "no epic with id=" + epicId;
         testSubtask.setEpicId(epicId);
 
-        long id = manager.addSubtask(testSubtask);
-
-        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added when epic does not exist");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotAddSubtaskToTask() {
         long taskId = manager.addTask(testTask);
+        String expectedMessage = "no epic with id=" + taskId;
         testSubtask.setEpicId(taskId);
 
-        long id = manager.addSubtask(testSubtask);
-
-        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added to regular task");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(testSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -580,11 +586,11 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         long subtaskId = manager.addSubtask(testSubtask);
+        String expectedMessage = "no epic with id=" + subtaskId;
         modifiedTestSubtask.setEpicId(subtaskId);
 
-        long id = manager.addSubtask(modifiedTestSubtask);
-
-        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added to subtask");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.addSubtask(modifiedTestSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -594,10 +600,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addSubtask(testSubtask);
         modifiedTestSubtask.setId(id);
 
-        int result = manager.updateSubtask(modifiedTestSubtask);
+        manager.updateSubtask(modifiedTestSubtask);
         Subtask savedSubtask = manager.getSubtask(id);
 
-        assertEquals(OK, result, "should return 0 when processed subtask update");
         assertEquals(id, savedSubtask.getId(), "subtask id changed");
         assertEquals(epicId, savedSubtask.getEpicId(), "epic id changed in subtask");
         assertEquals(MODIFIED_TEST_TITLE, savedSubtask.getTitle(), "subtask title not updated");
@@ -612,10 +617,9 @@ class InMemoryTaskManagerTest {
         long id = manager.addSubtask(testSubtask);
         emptySubtask.setId(id);
 
-        int result = manager.updateSubtask(emptySubtask);
+        manager.updateSubtask(emptySubtask);
         Subtask savedSubtask = manager.getSubtask(id);
 
-        assertEquals(OK, result, "should return 0 when processed subtask update");
         assertEquals(id, savedSubtask.getId(), "subtask id changed");
         assertEquals(epicId, savedSubtask.getEpicId(), "epic id changed in subtask");
         assertNull(savedSubtask.getTitle(), "subtask title not updated");
@@ -625,30 +629,32 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotUpdateNullSubtask() {
-        int result = manager.updateSubtask(null);
+        String expectedMessage = "cannot apply null update to subtask";
 
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for null subtask");
+        Exception exception = assertThrows(NullPointerException.class, () -> manager.updateSubtask(null));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateSubtaskWhenIdNotSet() {
+        String expectedMessage = "no subtask with id=null";
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
 
-        int result = manager.updateSubtask(testSubtask);
-
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for subtask with null id");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateSubtask(testSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test
     public void shouldNotUpdateNonExistingSubtask() {
+        long id = -1L;
+        String expectedMessage = "no subtask with id=" + id;
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
-        testSubtask.setId(-1L);
+        testSubtask.setId(id);
 
-        int result = manager.updateSubtask(testSubtask);
-
-        assertEquals(WRONG_ARGUMENT, result, "should not process update for unknown subtask");
+        Exception exception = assertThrows(NoSuchElementException.class, () -> manager.updateSubtask(testSubtask));
+        assertEquals(expectedMessage, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
     }
 
     @Test

--- a/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
+++ b/test/java/io/github/akuniutka/kanban/service/InMemoryTaskManagerTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static io.github.akuniutka.kanban.TestModels.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryTaskManagerTest {
     private static final int OK = 0;
@@ -22,21 +22,27 @@ class InMemoryTaskManagerTest {
     private HistoryManager historyManager;
     private Task emptyTask;
     private Task testTask;
+    private Task modifiedTestTask;
     private Epic emptyEpic;
     private Epic testEpic;
+    private Epic modifiedTestEpic;
     private Subtask emptySubtask;
     private Subtask testSubtask;
+    private Subtask modifiedTestSubtask;
 
     @BeforeEach
     public void setUp() {
         historyManager = new InMemoryHistoryManager();
         manager = new InMemoryTaskManager(historyManager);
         emptyTask = createTestTask();
-        testTask = createTestTask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+        testTask = createTaskFilledWithTestData();
+        modifiedTestTask = createTestTask(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION, MODIFIED_TEST_STATUS);
         emptyEpic = createTestEpic();
-        testEpic = createTestEpic(TEST_TITLE, TEST_DESCRIPTION);
+        testEpic = createEpicFilledWithTestData();
+        modifiedTestEpic = createTestEpic(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION);
         emptySubtask = createTestSubtask();
         testSubtask = createTestSubtask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+        modifiedTestSubtask = createTestSubtask(MODIFIED_TEST_TITLE, MODIFIED_TEST_DESCRIPTION, MODIFIED_TEST_STATUS);
     }
 
     @Test
@@ -57,6 +63,18 @@ class InMemoryTaskManagerTest {
     }
 
     @Test
+    public void shouldAllowAddTaskWithNullFields() {
+        long id = manager.addTask(emptyTask);
+        Task savedTask = manager.getTask(id);
+
+        assertNotNull(savedTask, "task not found");
+        assertEquals(id, savedTask.getId(), "task id differs from returned by manager class");
+        assertNull(savedTask.getTitle(), "task title changed");
+        assertNull(savedTask.getDescription(), "task description changed");
+        assertNull(savedTask.getStatus(), "task status changed");
+    }
+
+    @Test
     public void shouldNotAddNullTask() {
         long id = manager.addTask(null);
 
@@ -66,8 +84,8 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldNotOverwriteExistingTaskWhenAddingNewOne() {
         long id = manager.addTask(testTask);
-        emptyTask.setId(id);
-        long anotherId = manager.addTask(emptyTask);
+        modifiedTestTask.setId(id);
+        long anotherId = manager.addTask(modifiedTestTask);
         Task savedTask = manager.getTask(id);
 
         assertNotEquals(id, anotherId, "new task should have new id");
@@ -79,17 +97,32 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldUpdateTask() {
-        long id = manager.addTask(emptyTask);
-        testTask.setId(id);
+        long id = manager.addTask(testTask);
+        modifiedTestTask.setId(id);
 
-        int result = manager.updateTask(testTask);
+        int result = manager.updateTask(modifiedTestTask);
         Task savedTask = manager.getTask(id);
 
         assertEquals(OK, result, "should return 0 when processed task update");
         assertEquals(id, savedTask.getId(), "task id changed");
-        assertEquals(TEST_TITLE, savedTask.getTitle(), "task title not updated");
-        assertEquals(TEST_DESCRIPTION, savedTask.getDescription(), "task description not updated");
-        assertEquals(TEST_STATUS, savedTask.getStatus(), "task status not updated");
+        assertEquals(MODIFIED_TEST_TITLE, savedTask.getTitle(), "task title not updated");
+        assertEquals(MODIFIED_TEST_DESCRIPTION, savedTask.getDescription(), "task description not updated");
+        assertEquals(MODIFIED_TEST_STATUS, savedTask.getStatus(), "task status not updated");
+    }
+
+    @Test
+    public void shouldAllowUpdateTaskFieldsToNull() {
+        long id = manager.addTask(testTask);
+        emptyTask.setId(id);
+
+        int result = manager.updateTask(emptyTask);
+        Task savedTask = manager.getTask(id);
+
+        assertEquals(OK, result, "should return 0 when processed task update");
+        assertEquals(id, savedTask.getId(), "task id changed");
+        assertNull(savedTask.getTitle(), "task title not updated");
+        assertNull(savedTask.getDescription(), "task description not updated");
+        assertNull(savedTask.getStatus(), "task status not updated");
     }
 
     @Test
@@ -137,6 +170,17 @@ class InMemoryTaskManagerTest {
     }
 
     @Test
+    public void shouldAllowAddEpicWithNullFields() {
+        long id = manager.addEpic(emptyEpic);
+        Epic savedEpic = manager.getEpic(id);
+
+        assertNotNull(savedEpic, "epic not found");
+        assertEquals(id, savedEpic.getId(), "epic id differs from returned by manager");
+        assertNull(savedEpic.getTitle(), "epic title changed");
+        assertNull(savedEpic.getDescription(), "epic description changed");
+    }
+
+    @Test
     public void shouldNotAddNullEpic() {
         long id = manager.addEpic(null);
 
@@ -146,8 +190,8 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldNotOverwriteExistingEpicWhenAddingNewOne() {
         long id = manager.addEpic(testEpic);
-        emptyEpic.setId(id);
-        long anotherId = manager.addEpic(emptyEpic);
+        modifiedTestEpic.setId(id);
+        long anotherId = manager.addEpic(modifiedTestEpic);
         Epic savedEpic = manager.getEpic(id);
 
         assertNotEquals(id, anotherId, "new epic should have new id");
@@ -158,16 +202,30 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldUpdateEpic() {
-        long id = manager.addEpic(emptyEpic);
-        testEpic.setId(id);
+        long id = manager.addEpic(testEpic);
+        modifiedTestEpic.setId(id);
 
-        int result = manager.updateEpic(testEpic);
+        int result = manager.updateEpic(modifiedTestEpic);
         Epic savedEpic = manager.getEpic(id);
 
         assertEquals(OK, result, "should return 0 when processed epic update");
         assertEquals(id, savedEpic.getId(), "epic id changed");
-        assertEquals(TEST_TITLE, savedEpic.getTitle(), "epic title not updated");
-        assertEquals(TEST_DESCRIPTION, savedEpic.getDescription(), "epic description not updated");
+        assertEquals(MODIFIED_TEST_TITLE, savedEpic.getTitle(), "epic title not updated");
+        assertEquals(MODIFIED_TEST_DESCRIPTION, savedEpic.getDescription(), "epic description not updated");
+    }
+
+    @Test
+    public void shouldAllowUpdateEpicFieldsToNull() {
+        long id = manager.addEpic(testEpic);
+        emptyEpic.setId(id);
+
+        int result = manager.updateEpic(emptyEpic);
+        Epic savedEpic = manager.getEpic(id);
+
+        assertEquals(OK, result, "should return 0 when processed epic update");
+        assertEquals(id, savedEpic.getId(), "epic id changed");
+        assertNull(savedEpic.getTitle(), "epic title not updated");
+        assertNull(savedEpic.getDescription(), "epic description not updated");
     }
 
     @Test
@@ -196,13 +254,13 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldNotChangeEpicStatusByEpicUpdate(TaskStatus status) {
-        long id = manager.addEpic(emptyEpic);
+        long id = manager.addEpic(testEpic);
         testSubtask.setEpicId(id);
         testSubtask.setStatus(status);
         manager.addSubtask(testSubtask);
 
         for (TaskStatus newStatus : TaskStatus.values()) {
-            Epic epicUpdate = new Epic();
+            Epic epicUpdate = createEpicFilledWithTestData();
             epicUpdate.setId(id);
             epicUpdate.setStatus(newStatus);
 
@@ -242,11 +300,11 @@ class InMemoryTaskManagerTest {
         long id = manager.addEpic(testEpic);
         testSubtask.setEpicId(id);
         testSubtask.setStatus(TaskStatus.NEW);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(TaskStatus.NEW);
+        modifiedTestSubtask.setEpicId(id);
+        modifiedTestSubtask.setStatus(TaskStatus.NEW);
 
         manager.addSubtask(testSubtask);
-        manager.addSubtask(emptySubtask);
+        manager.addSubtask(modifiedTestSubtask);
         Epic savedEpic = manager.getEpic(id);
 
         assertEquals(TaskStatus.NEW, savedEpic.getStatus(),
@@ -256,19 +314,17 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldSetEpicToStatusNewWhenAllSubtasksSetToStatusNew(TaskStatus status) {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(TaskStatus.NEW);
         manager.addSubtask(testSubtask);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(status);
-        long subtaskId = manager.addSubtask(emptySubtask);
-        Subtask subtaskUpdate = new Subtask();
-        subtaskUpdate.setId(subtaskId);
-        subtaskUpdate.setStatus(TaskStatus.NEW);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(status);
+        long subtaskId = manager.addSubtask(modifiedTestSubtask);
+        Subtask subtaskUpdate = createTestSubtask(subtaskId, epicId, TEST_TITLE, TEST_DESCRIPTION, TaskStatus.NEW);
 
         manager.updateSubtask(subtaskUpdate);
-        Epic savedEpic = manager.getEpic(id);
+        Epic savedEpic = manager.getEpic(epicId);
 
         assertEquals(TaskStatus.NEW, savedEpic.getStatus(),
                 "epic should have status NEW when all subtasks have status NEW");
@@ -277,20 +333,18 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldSetEpicToStatusNewWhenAllSubtasksLeftHaveStatusNew(TaskStatus status) {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(TaskStatus.NEW);
         manager.addSubtask(testSubtask);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(TaskStatus.NEW);
-        manager.addSubtask(emptySubtask);
-        Subtask subtask = new Subtask();
-        subtask.setEpicId(id);
-        subtask.setStatus(status);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(TaskStatus.NEW);
+        manager.addSubtask(modifiedTestSubtask);
+        Subtask subtask = createTestSubtask(epicId, TEST_TITLE, TEST_DESCRIPTION, status);
         long subtaskId = manager.addSubtask(subtask);
 
         manager.removeSubtask(subtaskId);
-        Epic savedEpic = manager.getEpic(id);
+        Epic savedEpic = manager.getEpic(epicId);
 
         assertEquals(TaskStatus.NEW, savedEpic.getStatus(),
                 "epic should have status NEW when all subtasks have status NEW");
@@ -298,15 +352,15 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldSetEpicToStatusDoneWhenAllSubtasksHaveStatusDone() {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(TaskStatus.DONE);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(TaskStatus.DONE);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(TaskStatus.DONE);
 
         manager.addSubtask(testSubtask);
-        manager.addSubtask(emptySubtask);
-        Epic savedEpic = manager.getEpic(id);
+        manager.addSubtask(modifiedTestSubtask);
+        Epic savedEpic = manager.getEpic(epicId);
 
         assertEquals(TaskStatus.DONE, savedEpic.getStatus(),
                 "epic should have status DONE when all subtasks have status DONE");
@@ -315,19 +369,17 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldSetEpicToStatusDoneWhenAllSubtasksSetToStatusDone(TaskStatus status) {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(TaskStatus.DONE);
         manager.addSubtask(testSubtask);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(status);
-        long subtaskId = manager.addSubtask(emptySubtask);
-        Subtask subtaskUpdate = new Subtask();
-        subtaskUpdate.setId(subtaskId);
-        subtaskUpdate.setStatus(TaskStatus.DONE);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(status);
+        long subtaskId = manager.addSubtask(modifiedTestSubtask);
+        Subtask subtaskUpdate = createTestSubtask(subtaskId, epicId, TEST_TITLE, TEST_DESCRIPTION, TaskStatus.DONE);
 
         manager.updateSubtask(subtaskUpdate);
-        Epic savedEpic = manager.getEpic(id);
+        Epic savedEpic = manager.getEpic(epicId);
 
         assertEquals(TaskStatus.DONE, savedEpic.getStatus(),
                 "epic should have status DONE when all subtasks have status DONE");
@@ -336,20 +388,18 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldSetEpicToStatusDoneWhenAllSubtasksLeftHaveStatusDone(TaskStatus status) {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(TaskStatus.DONE);
         manager.addSubtask(testSubtask);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(TaskStatus.DONE);
-        manager.addSubtask(emptySubtask);
-        Subtask subtask = new Subtask();
-        subtask.setEpicId(id);
-        subtask.setStatus(status);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(TaskStatus.DONE);
+        manager.addSubtask(modifiedTestSubtask);
+        Subtask subtask = createTestSubtask(epicId, TEST_TITLE, TEST_DESCRIPTION, status);
         long subtaskId = manager.addSubtask(subtask);
 
         manager.removeSubtask(subtaskId);
-        Epic savedEpic = manager.getEpic(id);
+        Epic savedEpic = manager.getEpic(epicId);
 
         assertEquals(TaskStatus.DONE, savedEpic.getStatus(),
                 "epic should have status DONE when all subtasks have status DONE");
@@ -362,15 +412,15 @@ class InMemoryTaskManagerTest {
             if (statusA == statusB && statusA != TaskStatus.IN_PROGRESS) {
                 continue;
             }
-            long id = manager.addEpic(new Epic());
-            testSubtask.setEpicId(id);
+            long epicId = manager.addEpic(createEpicFilledWithTestData());
+            testSubtask.setEpicId(epicId);
             testSubtask.setStatus(statusA);
-            emptySubtask.setEpicId(id);
-            emptySubtask.setStatus(statusB);
+            modifiedTestSubtask.setEpicId(epicId);
+            modifiedTestSubtask.setStatus(statusB);
 
             manager.addSubtask(testSubtask);
-            manager.addSubtask(emptySubtask);
-            Epic savedEpic = manager.getEpic(id);
+            manager.addSubtask(modifiedTestSubtask);
+            Epic savedEpic = manager.getEpic(epicId);
 
             assertEquals(TaskStatus.IN_PROGRESS, savedEpic.getStatus(), "epic should have status IN_PROGRESS when "
                     + "not empty and neither all subtasks have status NEW nor all subtasks have status DONE");
@@ -380,24 +430,22 @@ class InMemoryTaskManagerTest {
     @ParameterizedTest
     @EnumSource(TaskStatus.class)
     public void shouldSetEpicToStatusInProgressWhenNotAllSubtasksSetToStatusNewNeitherDone(TaskStatus statusB) {
-        long id = manager.addEpic(testEpic);
-        testSubtask.setEpicId(id);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
         testSubtask.setStatus(statusB);
         long subtaskId = manager.addSubtask(testSubtask);
-        emptySubtask.setEpicId(id);
-        emptySubtask.setStatus(statusB);
-        manager.addSubtask(emptySubtask);
+        modifiedTestSubtask.setEpicId(epicId);
+        modifiedTestSubtask.setStatus(statusB);
+        manager.addSubtask(modifiedTestSubtask);
 
         for (TaskStatus statusA : TaskStatus.values()) {
             if (statusA == statusB && statusA != TaskStatus.IN_PROGRESS) {
                 continue;
             }
-            Subtask subtaskUpdate = new Subtask();
-            subtaskUpdate.setId(subtaskId);
-            subtaskUpdate.setStatus(statusA);
+            Subtask subtaskUpdate = createTestSubtask(subtaskId, epicId, TEST_TITLE, TEST_DESCRIPTION, statusA);
 
             manager.updateSubtask(subtaskUpdate);
-            Epic savedEpic = manager.getEpic(id);
+            Epic savedEpic = manager.getEpic(epicId);
 
             assertEquals(TaskStatus.IN_PROGRESS, savedEpic.getStatus(), "epic should have status IN_PROGRESS when "
                     + "not empty and neither all subtasks have status NEW nor all subtasks have status DONE");
@@ -412,20 +460,18 @@ class InMemoryTaskManagerTest {
                 if (statusA == statusB && statusB != TaskStatus.IN_PROGRESS) {
                     continue;
                 }
-                long id = manager.addEpic(new Epic());
-                testSubtask.setEpicId(id);
+                long epicId = manager.addEpic(createEpicFilledWithTestData());
+                testSubtask.setEpicId(epicId);
                 testSubtask.setStatus(statusA);
                 manager.addSubtask(testSubtask);
-                emptySubtask.setEpicId(id);
-                emptySubtask.setStatus(statusB);
-                manager.addSubtask(emptySubtask);
-                Subtask subtask = new Subtask();
-                subtask.setEpicId(id);
-                subtask.setStatus(statusC);
+                modifiedTestSubtask.setEpicId(epicId);
+                modifiedTestSubtask.setStatus(statusB);
+                manager.addSubtask(modifiedTestSubtask);
+                Subtask subtask = createTestSubtask(epicId, TEST_TITLE, TEST_DESCRIPTION, statusC);
                 long subtaskId = manager.addSubtask(subtask);
 
                 manager.removeSubtask(subtaskId);
-                Epic savedEpic = manager.getEpic(id);
+                Epic savedEpic = manager.getEpic(epicId);
 
                 assertEquals(TaskStatus.IN_PROGRESS, savedEpic.getStatus(), "epic should have status IN_PROGRESS when "
                         + "not empty and neither all subtasks have status NEW nor all subtasks have status DONE");
@@ -460,6 +506,22 @@ class InMemoryTaskManagerTest {
     }
 
     @Test
+    public void shouldAllowAddSubtaskWithNullFields() {
+        long epicId = manager.addEpic(testEpic);
+        emptySubtask.setEpicId(epicId);
+
+        long id = manager.addSubtask(emptySubtask);
+        Subtask savedSubtask = manager.getSubtask(id);
+
+        assertNotNull(savedSubtask, "subtask not found");
+        assertEquals(id, savedSubtask.getId(), "subtask id differs from returned by manager");
+        assertEquals(epicId, savedSubtask.getEpicId(), "epic id changed in subtask");
+        assertNull(savedSubtask.getTitle(), "subtask title changed");
+        assertNull(savedSubtask.getDescription(), "subtask description changed");
+        assertNull(savedSubtask.getStatus(), "subtask status changed");
+    }
+
+    @Test
     public void shouldNotAddNullSubtask() {
         long id = manager.addSubtask(null);
 
@@ -469,13 +531,13 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldNotOverwriteExistingSubtaskWhenAddingNewOne() {
         long epicId = manager.addEpic(testEpic);
-        long anotherEpicId = manager.addEpic(emptyEpic);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
         testSubtask.setEpicId(epicId);
-        emptySubtask.setEpicId(anotherEpicId);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
 
         long id = manager.addSubtask(testSubtask);
-        emptySubtask.setId(id);
-        long anotherId = manager.addSubtask(emptySubtask);
+        modifiedTestSubtask.setId(id);
+        long anotherId = manager.addSubtask(modifiedTestSubtask);
         Subtask savedSubtask = manager.getSubtask(id);
 
         assertNotEquals(id, anotherId, "new subtask should have new id");
@@ -488,7 +550,9 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotAddSubtaskToNull() {
-        assertTrue(manager.addSubtask(testSubtask) < 0L, "subtask with null epic id should not be added");
+        long id = manager.addSubtask(testSubtask);
+
+        assertEquals(WRONG_ARGUMENT, id, "subtask with null epic id should not be added");
     }
 
     @Test
@@ -496,7 +560,9 @@ class InMemoryTaskManagerTest {
         long epicId = -1L;
         testSubtask.setEpicId(epicId);
 
-        assertTrue(manager.addSubtask(testSubtask) < 0L, "subtask should not be added when epic does not exist");
+        long id = manager.addSubtask(testSubtask);
+
+        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added when epic does not exist");
     }
 
     @Test
@@ -504,35 +570,57 @@ class InMemoryTaskManagerTest {
         long taskId = manager.addTask(testTask);
         testSubtask.setEpicId(taskId);
 
-        assertTrue(manager.addSubtask(testSubtask) < 0L, "subtask should not be added to regular task");
+        long id = manager.addSubtask(testSubtask);
+
+        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added to regular task");
     }
 
     @Test
     public void shouldNotAddSubtaskToSubtask() {
         long epicId = manager.addEpic(testEpic);
-        emptySubtask.setEpicId(epicId);
-        long subtaskId = manager.addSubtask(emptySubtask);
-        testSubtask.setEpicId(subtaskId);
+        testSubtask.setEpicId(epicId);
+        long subtaskId = manager.addSubtask(testSubtask);
+        modifiedTestSubtask.setEpicId(subtaskId);
 
-        assertTrue(manager.addSubtask(testSubtask) < 0L, "subtask should not be added to subtask");
+        long id = manager.addSubtask(modifiedTestSubtask);
+
+        assertEquals(WRONG_ARGUMENT, id, "subtask should not be added to subtask");
     }
 
     @Test
     public void shouldUpdateSubtask() {
         long epicId = manager.addEpic(testEpic);
-        emptySubtask.setEpicId(epicId);
-        long id = manager.addSubtask(emptySubtask);
-        testSubtask.setId(id);
+        testSubtask.setEpicId(epicId);
+        long id = manager.addSubtask(testSubtask);
+        modifiedTestSubtask.setId(id);
 
-        int result = manager.updateSubtask(testSubtask);
+        int result = manager.updateSubtask(modifiedTestSubtask);
         Subtask savedSubtask = manager.getSubtask(id);
 
         assertEquals(OK, result, "should return 0 when processed subtask update");
         assertEquals(id, savedSubtask.getId(), "subtask id changed");
         assertEquals(epicId, savedSubtask.getEpicId(), "epic id changed in subtask");
-        assertEquals(TEST_TITLE, savedSubtask.getTitle(), "subtask title not updated");
-        assertEquals(TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description not updated");
-        assertEquals(TEST_STATUS, savedSubtask.getStatus(), "subtask status not updated");
+        assertEquals(MODIFIED_TEST_TITLE, savedSubtask.getTitle(), "subtask title not updated");
+        assertEquals(MODIFIED_TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description not updated");
+        assertEquals(MODIFIED_TEST_STATUS, savedSubtask.getStatus(), "subtask status not updated");
+    }
+
+    @Test
+    public void shouldAllowUpdateSubtaskFieldsToNull() {
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        long id = manager.addSubtask(testSubtask);
+        emptySubtask.setId(id);
+
+        int result = manager.updateSubtask(emptySubtask);
+        Subtask savedSubtask = manager.getSubtask(id);
+
+        assertEquals(OK, result, "should return 0 when processed subtask update");
+        assertEquals(id, savedSubtask.getId(), "subtask id changed");
+        assertEquals(epicId, savedSubtask.getEpicId(), "epic id changed in subtask");
+        assertNull(savedSubtask.getTitle(), "subtask title not updated");
+        assertNull(savedSubtask.getDescription(), "subtask description not updated");
+        assertNull(savedSubtask.getStatus(), "subtask status not updated");
     }
 
     @Test
@@ -544,6 +632,9 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotUpdateSubtaskWhenIdNotSet() {
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+
         int result = manager.updateSubtask(testSubtask);
 
         assertEquals(WRONG_ARGUMENT, result, "should not process update for subtask with null id");
@@ -551,7 +642,9 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotUpdateNonExistingSubtask() {
-        testTask.setId(-1L);
+        long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        testSubtask.setId(-1L);
 
         int result = manager.updateSubtask(testSubtask);
 
@@ -585,7 +678,7 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldReturnSubtasksOfEpic() {
         long epicId = manager.addEpic(testEpic);
-        long anotherEpicId = manager.addEpic(emptyEpic);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
         Subtask subtaskA = createSubtaskFilledWithTestDataAndEpicId(epicId);
         Subtask subtaskB = createSubtaskFilledWithTestDataAndEpicId(epicId);
         Subtask subtaskC = createSubtaskFilledWithTestDataAndEpicId(epicId);
@@ -604,15 +697,15 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldNotChangeEpicSubtasksListByEpicUpdate() {
-        long id = manager.addEpic(emptyEpic);
+        long id = manager.addEpic(testEpic);
         testSubtask.setEpicId(id);
-        emptySubtask.setEpicId(id);
+        modifiedTestSubtask.setEpicId(id);
         long subtaskIdA = manager.addSubtask(testSubtask);
-        long subtaskIdB = manager.addSubtask(emptySubtask);
+        long subtaskIdB = manager.addSubtask(modifiedTestSubtask);
         List<Subtask> expectedSubtaskList = createListOfSubtasksWithPresetIds(subtaskIdA, subtaskIdB);
-        testEpic.setId(id);
+        modifiedTestEpic.setId(id);
 
-        manager.updateEpic(testEpic);
+        manager.updateEpic(modifiedTestEpic);
         List<Subtask> actualSubtaskList = manager.getEpicSubtasks(id);
 
         assertEquals(expectedSubtaskList, actualSubtaskList, "epic update should change list of epic subtasks");
@@ -620,13 +713,16 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldReturnListOfTasks() {
-        long taskIdA = manager.addTask(new Task());
-        long taskIdB = manager.addTask(new Task());
-        long taskIdC = manager.addTask(new Task());
+        Task taskA = createTaskFilledWithTestData();
+        Task taskB = createTaskFilledWithTestData();
+        Task taskC = createTaskFilledWithTestData();
+        long taskIdA = manager.addTask(taskA);
+        long taskIdB = manager.addTask(taskB);
+        long taskIdC = manager.addTask(taskC);
         manager.removeTask(taskIdB);
         testTask.setId(taskIdA);
-        emptyTask.setId(taskIdC);
-        List<Task> expectedTaskList = List.of(testTask, emptyTask);
+        modifiedTestTask.setId(taskIdC);
+        List<Task> expectedTaskList = List.of(testTask, modifiedTestTask);
 
         List<Task> actualTaskList = manager.getTasks();
 
@@ -636,7 +732,7 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveAllTasks() {
         manager.addTask(testTask);
-        manager.addTask(emptyTask);
+        manager.addTask(modifiedTestTask);
 
         manager.removeTasks();
         List<Task> tasks = manager.getTasks();
@@ -646,13 +742,16 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldReturnListOfEpics() {
-        long epicIdA = manager.addEpic(new Epic());
-        long epicIdB = manager.addEpic(new Epic());
-        long epicIdC = manager.addEpic(new Epic());
+        Epic epicA = createEpicFilledWithTestData();
+        Epic epicB = createEpicFilledWithTestData();
+        Epic epicC = createEpicFilledWithTestData();
+        long epicIdA = manager.addEpic(epicA);
+        long epicIdB = manager.addEpic(epicB);
+        long epicIdC = manager.addEpic(epicC);
         manager.removeEpic(epicIdB);
         testEpic.setId(epicIdA);
-        emptyEpic.setId(epicIdC);
-        List<Epic> expectedEpicList = List.of(testEpic, emptyEpic);
+        modifiedTestEpic.setId(epicIdC);
+        List<Epic> expectedEpicList = List.of(testEpic, modifiedTestEpic);
 
         List<Epic> actualEpicList = manager.getEpics();
 
@@ -662,7 +761,7 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveAllEpics() {
         manager.addEpic(testEpic);
-        manager.addEpic(emptyEpic);
+        manager.addEpic(modifiedTestEpic);
 
         manager.removeEpics();
         List<Epic> epics = manager.getEpics();
@@ -673,7 +772,7 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldReturnListOfSubtasks() {
         long epicId = manager.addEpic(testEpic);
-        long anotherEpicId = manager.addEpic(emptyEpic);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
         Subtask subtaskA = createSubtaskFilledWithTestDataAndEpicId(epicId);
         Subtask subtaskB = createSubtaskFilledWithTestDataAndEpicId(epicId);
         Subtask subtaskC = createSubtaskFilledWithTestDataAndEpicId(epicId);
@@ -695,9 +794,9 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         manager.addSubtask(testSubtask);
-        long anotherEpicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(anotherEpicId);
-        manager.addSubtask(emptySubtask);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        manager.addSubtask(modifiedTestSubtask);
 
         manager.removeSubtasks();
         List<Subtask> subtasks = manager.getSubtasks();
@@ -710,9 +809,9 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         manager.addSubtask(testSubtask);
-        long anotherEpicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(anotherEpicId);
-        manager.addSubtask(emptySubtask);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        manager.addSubtask(modifiedTestSubtask);
 
         manager.removeEpics();
         List<Subtask> subtasks = manager.getSubtasks();
@@ -725,9 +824,9 @@ class InMemoryTaskManagerTest {
         long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         manager.addSubtask(testSubtask);
-        long anotherEpicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(anotherEpicId);
-        manager.addSubtask(emptySubtask);
+        long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        manager.addSubtask(modifiedTestSubtask);
 
         manager.removeSubtasks();
         List<Subtask> actualSubtaskListA = manager.getEpicSubtasks(epicId);
@@ -857,12 +956,12 @@ class InMemoryTaskManagerTest {
 
     @Test
     public void shouldRemoveSubtaskOfEpicFromHistory() {
-        final long epicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(epicId);
-        final long idA = manager.addSubtask(emptySubtask);
-        final long anotherEpicId = manager.addEpic(testEpic);
-        testSubtask.setEpicId(anotherEpicId);
-        final long idB = manager.addSubtask(testSubtask);
+        final long epicId = manager.addEpic(testEpic);
+        testSubtask.setEpicId(epicId);
+        final long idA = manager.addSubtask(testSubtask);
+        final long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        final long idB = manager.addSubtask(modifiedTestSubtask);
         manager.getSubtask(idA);
         manager.getSubtask(idB);
 
@@ -874,15 +973,15 @@ class InMemoryTaskManagerTest {
         Subtask savedSubtask = (Subtask) tasks.getFirst();
         assertEquals(idB, savedSubtask.getId(), "subtask id should not change");
         assertEquals(anotherEpicId, savedSubtask.getEpicId(), "epic id of status should not change");
-        assertEquals(TEST_TITLE, savedSubtask.getTitle(), "subtask title should not change");
-        assertEquals(TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description should not change");
-        assertEquals(TEST_STATUS, savedSubtask.getStatus(), "subtask status should not change");
+        assertEquals(MODIFIED_TEST_TITLE, savedSubtask.getTitle(), "subtask title should not change");
+        assertEquals(MODIFIED_TEST_DESCRIPTION, savedSubtask.getDescription(), "subtask description should not change");
+        assertEquals(MODIFIED_TEST_STATUS, savedSubtask.getStatus(), "subtask status should not change");
     }
 
     @Test
     public void shouldRemoveAllTasksFromHistory() {
         final long idA = manager.addTask(testTask);
-        final long idB = manager.addTask(emptyTask);
+        final long idB = manager.addTask(modifiedTestTask);
         manager.getTask(idA);
         manager.getTask(idB);
 
@@ -895,7 +994,7 @@ class InMemoryTaskManagerTest {
     @Test
     public void shouldRemoveAllEpicsFromHistory() {
         final long idA = manager.addEpic(testEpic);
-        final long idB = manager.addEpic(emptyEpic);
+        final long idB = manager.addEpic(modifiedTestEpic);
         manager.getEpic(idA);
         manager.getEpic(idB);
 
@@ -910,9 +1009,9 @@ class InMemoryTaskManagerTest {
         final long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         final long idA = manager.addSubtask(testSubtask);
-        final long anotherEpicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(anotherEpicId);
-        final long idB = manager.addSubtask(emptySubtask);
+        final long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        final long idB = manager.addSubtask(modifiedTestSubtask);
         manager.getSubtask(idA);
         manager.getSubtask(idB);
 
@@ -927,9 +1026,9 @@ class InMemoryTaskManagerTest {
         final long epicId = manager.addEpic(testEpic);
         testSubtask.setEpicId(epicId);
         final long idA = manager.addSubtask(testSubtask);
-        final long anotherEpicId = manager.addEpic(emptyEpic);
-        emptySubtask.setEpicId(anotherEpicId);
-        final long idB = manager.addSubtask(emptySubtask);
+        final long anotherEpicId = manager.addEpic(modifiedTestEpic);
+        modifiedTestSubtask.setEpicId(anotherEpicId);
+        final long idB = manager.addSubtask(modifiedTestSubtask);
         manager.getSubtask(idA);
         manager.getSubtask(idB);
 
@@ -937,6 +1036,14 @@ class InMemoryTaskManagerTest {
         List<Task> tasks = historyManager.getHistory();
 
         assertTrue(tasks.isEmpty());
+    }
+
+    private Task createTaskFilledWithTestData() {
+        return createTestTask(TEST_TITLE, TEST_DESCRIPTION, TEST_STATUS);
+    }
+
+    private Epic createEpicFilledWithTestData() {
+        return createTestEpic(TEST_TITLE, TEST_DESCRIPTION);
     }
 
     private Subtask createSubtaskFilledWithTestDataAndEpicId(long epicId) {

--- a/test/java/io/github/akuniutka/kanban/util/CSVLineParserTest.java
+++ b/test/java/io/github/akuniutka/kanban/util/CSVLineParserTest.java
@@ -1,0 +1,315 @@
+package io.github.akuniutka.kanban.util;
+
+import io.github.akuniutka.kanban.exception.CSVParsingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CSVLineParserTest {
+    private static final String WRONG_EXCEPTION_MESSAGE = "message for exception is wrong";
+    private static final String WRONG_POSITION = "wrong position in string";
+
+    @Test
+    public void shouldInstantiateCSVLineParser() {
+        new CSVLineParser("");
+    }
+
+    @Test
+    public void shouldThrowWhenNullStringPassed() {
+        Exception exception = assertThrows(NullPointerException.class, () -> new CSVLineParser(null));
+        assertEquals("cannot parse null string", exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldReturnTokenWhenEmptyLine() {
+        CSVLineParser parser = new CSVLineParser("");
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(0, token.position(), "wrong starting position of token");
+        assertEquals("", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnEmptyTokenInStartOfLine() {
+        CSVLineParser parser = new CSVLineParser(",,");
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(0, token.position(), "wrong starting position of token");
+        assertEquals("", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnEmptyTokenInMiddleOfLine() {
+        CSVLineParser parser = new CSVLineParser(",,");
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(1, token.position(), "wrong starting position of token");
+        assertEquals("", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnEmptyTokenInEndOfLine() {
+        CSVLineParser parser = new CSVLineParser(",,");
+        parser.next();
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(2, token.position(), "wrong starting position of token");
+        assertEquals("", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnNonEmptyTokenInStartOfLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB,tokenC");
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(0, token.position(), "wrong starting position of token");
+        assertEquals("tokenA", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnNonEmptyTokenInMiddleOfLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB,tokenC");
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(7, token.position(), "wrong starting position of token");
+        assertEquals("tokenB", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnNonEmptyTokenInEndOfLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB,tokenC");
+        parser.next();
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(14, token.position(), "wrong starting position of token");
+        assertEquals("tokenC", token.value(), "wrong value of token");
+        assertFalse(token.isQuoted(), "token should be reported as not quoted");
+    }
+
+    @Test
+    public void shouldReturnQuotedTokenInStartOfLine() {
+        CSVLineParser parser = new CSVLineParser("\"tokenA\",tokenB,tokenC");
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(0, token.position(), "wrong starting position of token");
+        assertEquals("tokenA", token.value(), "wrong value of token");
+        assertTrue(token.isQuoted(), "token should be reported as quoted");
+    }
+
+    @Test
+    public void shouldReturnQuotedTokenInMiddleOfLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,\"tokenB\",tokenC");
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(7, token.position(), "wrong starting position of token");
+        assertEquals("tokenB", token.value(), "wrong value of token");
+        assertTrue(token.isQuoted(), "token should be reported as quoted");
+    }
+
+    @Test
+    public void shouldReturnQuotedTokenInEndOfLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB,\"tokenC\"");
+        parser.next();
+        parser.next();
+        CSVToken token = parser.next();
+
+        assertNotNull(token, "should return nonnull token");
+        assertEquals(14, token.position(), "wrong starting position of token");
+        assertEquals("tokenC", token.value(), "wrong value of token");
+        assertTrue(token.isQuoted(), "token should be reported as quoted");
+    }
+
+    @Test
+    public void shouldHaveNextWhenLineEmpty() {
+        CSVLineParser parser = new CSVLineParser("");
+
+        assertTrue(parser.hasNext(), "empty line should have one token");
+    }
+
+    @Test
+    public void shouldHaveNextWhenLineNotEmpty() {
+        CSVLineParser parser = new CSVLineParser("token");
+
+        assertTrue(parser.hasNext(), "nonempty line should have one token");
+    }
+
+    @Test
+    public void shouldHaveNextWhenSeveralTokensInLine() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB,tokenC");
+
+        assertTrue(parser.hasNext(), "nonempty line should have one token");
+    }
+
+    @Test
+    public void shouldHaveNextWhenNotLastTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB");
+        parser.next();
+
+        assertTrue(parser.hasNext(), "should be another token available");
+    }
+
+    @Test
+    public void shouldHaveNoNextTokenWhenTokenRetrievedFromEmptyLine() {
+        CSVLineParser parser = new CSVLineParser("");
+        parser.next();
+
+        assertFalse(parser.hasNext(), "should have no more tokens");
+    }
+
+    @Test
+    public void shouldHaveNoNextTokenWhenTheOnlyTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("token");
+        parser.next();
+
+        assertFalse(parser.hasNext(), "should have no more tokens");
+    }
+
+    @Test
+    public void shouldHaveNoNextTokenWhenTheOnlyQuotedTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("\"token\"");
+        parser.next();
+
+        assertFalse(parser.hasNext(), "should have no more tokens");
+    }
+
+    @Test
+    public void shouldHaveNoNextTokenWhenLastTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB");
+        parser.next();
+        parser.next();
+
+        assertFalse(parser.hasNext(), "should have no more tokens");
+    }
+
+    @Test
+    public void shouldHaveNoNextTokenWhenLastQuotedTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("tokenA,\"tokenB\"");
+        parser.next();
+        parser.next();
+
+        assertFalse(parser.hasNext(), "should have no more tokens");
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingAfterTokenRetrievedFromEmptyLine() {
+        CSVLineParser parser = new CSVLineParser("");
+        String expectedMessage = "unexpected end of line";
+        int expectedPosition = 1;
+        parser.next();
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingAfterTheOnlyTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("token");
+        String expectedMessage = "unexpected end of line";
+        int expectedPosition = 6;
+        parser.next();
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingAfterTheOnlyQuotedTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("\"token\"");
+        String expectedMessage = "unexpected end of line";
+        int expectedPosition = 8;
+        parser.next();
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingAfterLastTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("tokenA,tokenB");
+        String expectedMessage = "unexpected end of line";
+        int expectedPosition = 14;
+        parser.next();
+        parser.next();
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenRetrievingAfterLastQuotedTokenRetrieved() {
+        CSVLineParser parser = new CSVLineParser("tokenA,\"tokenB\"");
+        String expectedMessage = "unexpected end of line";
+        int expectedPosition = 16;
+        parser.next();
+        parser.next();
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenQuoteAfterNonComma() {
+        CSVLineParser parser = new CSVLineParser("tokenA\"tokenB\"tokenC");
+        String expectedMessage = "unexpected double quote";
+        int expectedPosition = 7;
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenNoClosingQuote() {
+        CSVLineParser parser = new CSVLineParser("\"tokenA.tokenB,tokenC");
+        String expectedMessage = "double quote expected";
+        int expectedPosition = 22;
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    public void shouldThrowWhenNonCommaAfterQuote() {
+        CSVLineParser parser = new CSVLineParser("\"tokenA\"tokenB,tokenC");
+        String expectedMessage = "comma expected";
+        int expectedPosition = 9;
+
+        CSVParsingException exception = assertThrows(CSVParsingException.class, parser::next);
+        assertEquals(expectedMessage, exception.getShortMessage(), WRONG_EXCEPTION_MESSAGE);
+        assertEquals(expectedPosition, exception.getPositionInLine(), WRONG_POSITION);
+        assertEquals(expectedMessage + " at " + expectedPosition, exception.getMessage(), WRONG_EXCEPTION_MESSAGE);
+    }
+}


### PR DESCRIPTION
Achieve a sprint #7 goal: add a new task manager class which:
- Makes a snapshot of the current data and saves it to a file on every change to tasks, epics, subtasks.
- May load data from such a file on startup.
    
Also fix README: a limit for visited tasks history depth was removed.